### PR TITLE
Forcing clikit version to allow compilation on Ubuntu 16 (Xenial)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ pytimeparse==1.1.8
 PyYAML==5.1.1
 Flask-SSLify==0.1.5
 Flask-Mail==0.9.1
+clikit==0.4.0


### PR DESCRIPTION
pip install -r requirements.txt fails on Ubuntu 16.04.4 LTS (Xenial Xerus) because the latest clikit (0.4.1) isn't supported and has a flow-on effect

https://github.com/sdispater/clikit/issues/7
https://github.com/python-poetry/poetry/issues/1744
https://github.com/sdispater/cleo/issues/70

This change restricts us to clikit 0.4.0 for now