### PR TITLE
routes/index.py: Make package 'onelogin.saml2.utils' optional

### DIFF
--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -6,7 +6,6 @@ import datetime
 import ipaddress
 from distutils.util import strtobool
 from yaml import Loader, load
-from onelogin.saml2.utils import OneLogin_Saml2_Utils
 from flask import Blueprint, render_template, make_response, url_for, current_app, g, session, request, redirect, abort
 from flask_login import login_user, logout_user, login_required, current_user
 
@@ -847,6 +846,7 @@ def dyndns_update():
 def saml_login():
     if not current_app.config.get('SAML_ENABLED'):
         abort(400)
+    from onelogin.saml2.utils import OneLogin_Saml2_Utils
     req = saml.prepare_flask_request(request)
     auth = saml.init_saml_auth(req)
     redirect_url = OneLogin_Saml2_Utils.get_self_url(req) + url_for(
@@ -859,7 +859,7 @@ def saml_metadata():
     if not current_app.config.get('SAML_ENABLED'):
         current_app.logger.error("SAML authentication is disabled.")
         abort(400)
-
+    from onelogin.saml2.utils import OneLogin_Saml2_Utils
     req = saml.prepare_flask_request(request)
     auth = saml.init_saml_auth(req)
     settings = auth.get_settings()


### PR DESCRIPTION
The onelogin package is not part of all saml packages for whatever
reason (e.g. Debian) and not easily installable from pypi (requires
CC toolchain).

As the onelogin functionality is already guarded by whether
SAML_ENABLED is set in other places (services/saml.py), also do so
in routes/index.py.