### PR TITLE
dyndns: Respond with HTTP header 'WWW-Authenticate' to unauthed requests

### DIFF
--- a/powerdnsadmin/decorators.py
+++ b/powerdnsadmin/decorators.py
@@ -1,7 +1,7 @@
 import base64
 import binascii
 from functools import wraps
-from flask import g, request, abort, current_app, render_template
+from flask import g, request, abort, current_app, Response
 from flask_login import current_user
 
 from .models import User, ApiKey, Setting, Domain, Setting
@@ -301,7 +301,7 @@ def dyndns_login_required(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
         if current_user.is_authenticated is False:
-            return render_template('dyndns.html', response='badauth'), 200
+            return Response(headers={'WWW-Authenticate': 'Basic'}, status=401)
         return f(*args, **kwargs)
 
     return decorated_function


### PR DESCRIPTION
The common procedure for HTTP Basic Auth is that a client does /not/
immediately send out credentials via an 'Authorization'-header, but to
wait until the server tells the client to do so - which the server
indicates via the 'WWW-Authenticate'-header.

PowerDNS-Admin (and flask in general), though, abort the whole
communication if no Authorization header was found in the initial
request - resulting in '200 "badauth"'.

While this might work for /some/ HTTP clients - which right away add an
Authorization header crafted from provided credentials (via args or
extracted from given URL), this is /not/ standard and /not/ common.

Hence add the 'WWW-Authenticate'-header for every unauthenticated call
checking for dyndns authorisation.

Note, though, this changes the status code from 200 to 401 in this case,
which - given the explanation why 200 was chosen in the first place -
might cause side effects.