### PR TITLE
Add button for admin page in single Domain view

### DIFF
--- a/powerdnsadmin/templates/domain.html
+++ b/powerdnsadmin/templates/domain.html
@@ -25,6 +25,9 @@
                     <button type="button" class="btn btn-flat btn-primary pull-left button_add_record" id="{{ domain.name }}">
                         Add Record&nbsp;<i class="fa fa-plus"></i>
                     </button>
+                    <button type="button" style="position: relative; margin-left: 20px" class="btn btn-flat btn-primary pull-left btn-danger" onclick="window.location.href='{{ url_for('domain.setting', domain_name=domain.name) }}'">
+                        Admin&nbsp;<i class="fa fa-cog"></i>
+                      </button>
                     <button type="button" class="btn btn-flat btn-primary pull-right button_apply_changes" id="{{ domain.name }}" value="{{ domain.serial }}">
                         Apply Changes&nbsp;<i class="fa fa-floppy-o"></i>
                     </button>

--- a/powerdnsadmin/templates/domain.html
+++ b/powerdnsadmin/templates/domain.html
@@ -25,9 +25,6 @@
                     <button type="button" class="btn btn-flat btn-primary pull-left button_add_record" id="{{ domain.name }}">
                         Add Record&nbsp;<i class="fa fa-plus"></i>
                     </button>
-                    <button type="button" style="position: relative; margin-left: 20px" class="btn btn-flat btn-primary pull-left btn-danger" onclick="window.location.href='{{ url_for('domain.setting', domain_name=domain.name) }}'">
-                        Admin&nbsp;<i class="fa fa-cog"></i>
-                      </button>
                     <button type="button" class="btn btn-flat btn-primary pull-right button_apply_changes" id="{{ domain.name }}" value="{{ domain.serial }}">
                         Apply Changes&nbsp;<i class="fa fa-floppy-o"></i>
                     </button>
@@ -35,6 +32,11 @@
                     <button type="button" class="btn btn-flat btn-primary pull-left button_update_from_master" id="{{ domain.name }}">
                         Update from Master&nbsp;<i class="fa fa-download"></i>
                     </button>
+                    {% endif %}
+                    {% if current_user.role.name in ['Administrator', 'Operator'] %}
+                    <button type="button" style="position: relative; margin-left: 20px" class="btn btn-flat btn-primary pull-left btn-danger" onclick="window.location.href='{{ url_for('domain.setting', domain_name=domain.name) }}'">
+                        Admin&nbsp;<i class="fa fa-cog"></i>
+                      </button>
                     {% endif %}
                     {% if current_user.role.name in ['Administrator', 'Operator'] or SETTING.get('allow_user_view_history') %}
                     <button type="button" style="position: relative; margin-left: 20px" class="btn btn-flat btn-primary button_changelog" id="{{ domain.name }}">


### PR DESCRIPTION
While working with PDA I had often the use to get from the Domain Records to the Admin page of it, to for example assign an account to it.

Therefore it would be nice to have a button for it to get to there.

![example](https://user-images.githubusercontent.com/1383479/145547099-cdb368ee-ef6f-4b6a-b319-c5d77e5e4ff1.PNG)
