### PR TITLE
build-and-publish.yml: Build for linux/arm64

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -26,6 +26,10 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
 
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
@@ -43,6 +47,7 @@ jobs:
           context: ./
           file: ./docker/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ngoduykhanh/powerdns-admin:latest
 
       - name: Build release image
@@ -52,5 +57,6 @@ jobs:
           context: ./
           file: ./docker/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Update the build-and-publish workflow to build for both linux/amd64 and linux/arm64 allowing the Docker image to be deployed on arm64 based devices such as a Raspberry Pi.

I have tested this on my own fork and deployed the latest image to [dcroper/powerdns-admin](https://hub.docker.com/repository/docker/dcroper/powerdns-admin) and have successfully run this image on a Raspberry Pi 4 running Debian Linux (not Raspberry Pi OS).