### PR TITLE
Display correct record types in forward/reverse zones

### DIFF
--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -127,10 +127,7 @@ def domain(domain_name):
         # Unsupported version
         abort(500)
 
-    if not re.search(r'ip6\.arpa|in-addr\.arpa$', domain_name):
-        editable_records = forward_records_allow_to_edit
-    else:
-        editable_records = reverse_records_allow_to_edit
+    editable_records = records_allow_to_edit
 
     return render_template('domain.html',
                            domain=domain,

--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -70,7 +70,6 @@ def domain(domain_name):
         abort(500)
 
     quick_edit = Setting().get('record_quick_edit')
-    records_allow_to_edit = Setting().get_records_allow_to_edit()
     forward_records_allow_to_edit = Setting(
     ).get_forward_records_allow_to_edit()
     reverse_records_allow_to_edit = Setting(

--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -78,6 +78,11 @@ def domain(domain_name):
     ttl_options = Setting().get_ttl_options()
     records = []
 
+    if re.search(r'ip6\.arpa|in-addr\.arpa$', domain_name):
+        records_allow_to_edit = reverse_records_allow_to_edit
+    else:
+        records_allow_to_edit = forward_records_allow_to_edit
+
     # Render the "records" to display in HTML datatable
     #
     # BUG: If we have multiple records with the same name


### PR DESCRIPTION
Fix for issue #1093.

Previously, all zones would display a record type if editing it was allowed for forward OR reverse zones.
Now, it is only displayed in the zones where it has been allowed (forward, reverse, or both).

Developed in collaboration with @kkmanos for our [team](https://github.com/gunet).