### PR TITLE
Option to forbid the creation of domain if it exists as a record

### DIFF
--- a/powerdnsadmin/models/domain.py
+++ b/powerdnsadmin/models/domain.py
@@ -15,9 +15,6 @@ from .domain_setting import DomainSetting
 from .history import History
 
 
-def by_record_content_pair(e):
-    return e[0]['content']
-
 class Domain(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(255), index=True, unique=True)
@@ -208,7 +205,7 @@ class Domain(db.Model):
             domain_master_ips=[],
             account_name=None):
         """
-        Add a domain to power dns, only if there is no record of the same name in the upper domain
+        Add a domain to power dns
         """
 
         headers = {'X-API-Key': self.PDNS_API_KEY}
@@ -246,7 +243,6 @@ class Domain(db.Model):
                     return {'status': 'error', 'msg': 'Domain already exists'}
                 return {'status': 'error', 'msg': jdata['error']}
             else:
-
                 current_app.logger.info(
                     'Added domain successfully to PowerDNS: {0}'.format(
                         domain_name))

--- a/powerdnsadmin/models/domain.py
+++ b/powerdnsadmin/models/domain.py
@@ -15,6 +15,9 @@ from .domain_setting import DomainSetting
 from .history import History
 
 
+def by_record_content_pair(e):
+    return e[0]['content']
+
 class Domain(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(255), index=True, unique=True)
@@ -197,6 +200,42 @@ class Domain(db.Model):
                     domain.name, e))
                 raise
 
+    def get_rrsets(self, domain):
+        """
+        Query domain's rrsets via PDNS API
+        """
+        headers = {'X-API-Key': self.PDNS_API_KEY}
+        try:
+            jdata = utils.fetch_json(urljoin(
+                self.PDNS_STATS_URL, self.API_EXTENDED_URL +
+                '/servers/localhost/zones/{0}'.format(domain)),
+                                     timeout=int(
+                                         Setting().get('pdns_api_timeout')),
+                                     headers=headers,
+                                     verify=Setting().get('verify_ssl_connections'))
+        except Exception as e:
+            current_app.logger.error(
+                "Cannot fetch domain's record data from remote powerdns api. DETAIL: {0}"
+                .format(e))
+            return []
+
+        rrsets=[]
+        for r in jdata['rrsets']:
+            if len(r['records']) == 0:
+                continue
+
+            while len(r['comments'])<len(r['records']):
+                r['comments'].append({"content": "", "account": ""})
+            r['records'], r['comments'] = (list(t) for t in zip(*sorted(zip(r['records'], r['comments']), key=by_record_content_pair)))
+            rrsets.append(r)
+
+        return rrsets
+
+    def get_upper_domain(self, domain_name):
+        upper_domain_name = '.'.join(domain_name.split('.')[1:])
+        print("Upper Domain Name: {}".format(upper_domain_name))
+        return upper_domain_name
+
     def add(self,
             domain_name,
             domain_type,
@@ -205,7 +244,7 @@ class Domain(db.Model):
             domain_master_ips=[],
             account_name=None):
         """
-        Add a domain to power dns
+        Add a domain to power dns, only if there is no record of the same name in the upper domain
         """
 
         headers = {'X-API-Key': self.PDNS_API_KEY}
@@ -229,6 +268,20 @@ class Domain(db.Model):
         }
 
         try:
+            # Test if a record same as the domain already exists in an upper level domain
+            upper_domain_name = self.get_upper_domain(domain_name[:-1])
+            while (upper_domain_name != ''):
+                if self.get_id_by_name(upper_domain_name) != None:
+                    rrsets = self.get_rrsets(upper_domain_name)
+                    for r in rrsets:
+                        print(r)
+                        if r['name'] == domain_name:
+                            current_app.logger.error(
+                            "A record of {} already exists in {}".format(r['name'], upper_domain_name))
+                            return {'status': 'error', 'msg': "A record of {} already exists in {}".format(r['name'], upper_domain_name)}
+                else:
+                    current_app.logger.error("")
+                upper_domain_name = self.get_upper_domain(upper_domain_name)
             jdata = utils.fetch_json(
                 urljoin(self.PDNS_STATS_URL,
                         self.API_EXTENDED_URL + '/servers/localhost/zones'),
@@ -243,6 +296,7 @@ class Domain(db.Model):
                     return {'status': 'error', 'msg': 'Domain already exists'}
                 return {'status': 'error', 'msg': jdata['error']}
             else:
+
                 current_app.logger.info(
                     'Added domain successfully to PowerDNS: {0}'.format(
                         domain_name))

--- a/powerdnsadmin/models/setting.py
+++ b/powerdnsadmin/models/setting.py
@@ -190,7 +190,8 @@ class Setting(db.Model):
         'otp_field_enabled': True,
         'custom_css': '',
         'otp_force': False,
-        'max_history_records': 1000
+        'max_history_records': 1000,
+        'deny_domain_override': False
     }
 
     def __init__(self, id=None, name=None, value=None):

--- a/powerdnsadmin/routes/admin.py
+++ b/powerdnsadmin/routes/admin.py
@@ -1260,7 +1260,7 @@ def setting_basic():
             'allow_user_create_domain', 'allow_user_remove_domain', 'allow_user_view_history', 'bg_domain_updates', 'site_name',
             'session_timeout', 'warn_session_timeout', 'ttl_options',
             'pdns_api_timeout', 'verify_ssl_connections', 'verify_user_email',
-	          'delete_sso_accounts', 'otp_field_enabled', 'custom_css', 'enable_api_rr_history', 'max_history_records', 'otp_force'
+	          'delete_sso_accounts', 'otp_field_enabled', 'custom_css', 'enable_api_rr_history', 'max_history_records', 'otp_force', 'deny_domain_override'
         ]
 
         return render_template('admin_setting_basic.html', settings=settings)

--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -414,12 +414,9 @@ def add():
                         rrsets = rec.get_rrsets(upper_domain_name)
                         for r in rrsets:
                             if r['name'].rstrip('.') == domain_name:
-                                result = {'msg': 'Domain already exists as a record under {}'.format(upper_domain_name)}
                                 msg = 'Domain already exists as a record under {}'.format(upper_domain_name)
-                                #return render_template('errors/400.html', msg=result['msg']), 400
                                 return render_template('domain_add.html', domain_override_message=msg)
                     upper_domain_name = get_upper_domain(upper_domain_name)
-            ### END CHECK
             result = d.add(domain_name=domain_name,
                            domain_type=domain_type,
                            soa_edit_api=soa_edit_api,

--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -415,7 +415,9 @@ def add():
                         for r in rrsets:
                             if r['name'].rstrip('.') == domain_name:
                                 result = {'msg': 'Domain already exists as a record under {}'.format(upper_domain_name)}
-                                return render_template('errors/400.html', msg=result['msg']), 400
+                                msg = 'Domain already exists as a record under {}'.format(upper_domain_name)
+                                #return render_template('errors/400.html', msg=result['msg']), 400
+                                return render_template('domain_add.html', domain_override_message=msg)
                     upper_domain_name = get_upper_domain(upper_domain_name)
             ### END CHECK
             result = d.add(domain_name=domain_name,

--- a/powerdnsadmin/templates/domain_add.html
+++ b/powerdnsadmin/templates/domain_add.html
@@ -187,21 +187,13 @@
         modal.find('.modal-body p').text(info);
         modal.modal('show');
     });
-
-    function redirect_modal() {
-        modal.modal('hide');
-    }
-
-    function dothis() {
-        modal.find('.modal-body p').text(modal.find('#button_confirm_warn_modal'))
-    }
 {% endif %}
 </script>
 </div>
 <div class="modal fade" id="modal_warning">
   <div class="modal-dialog">
       <div class="modal-content modal-sm">
-          <div class="modal-header">
+          <div class="modal-header alert-danger">
               <button type="button" class="close" data-dismiss="modal" aria-label="Close" id="button_close_warn_modal">
                   <span aria-hidden="true">&times;</span>
               </button>

--- a/powerdnsadmin/templates/domain_add.html
+++ b/powerdnsadmin/templates/domain_add.html
@@ -178,3 +178,45 @@
     });
 </script>
 {% endblock %}
+{% block modals %}
+<script>
+{% if domain_override_message %}
+    $(document.body).ready(function () {
+        var modal = $("#modal_warning");
+        var info = "{{ domain_override_message }}";
+        modal.find('.modal-body p').text(info);
+        modal.modal('show');
+    });
+
+    function redirect_modal() {
+        modal.modal('hide');
+    }
+
+    function dothis() {
+        modal.find('.modal-body p').text(modal.find('#button_confirm_warn_modal'))
+    }
+{% endif %}
+</script>
+</div>
+<div class="modal fade" id="modal_warning">
+  <div class="modal-dialog">
+      <div class="modal-content modal-sm">
+          <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close" id="button_close_warn_modal">
+                  <span aria-hidden="true">&times;</span>
+              </button>
+              <h4 class="modal-title">WARNING</h4>
+          </div>
+          <div class="modal-body">
+              <p></p>
+          </div>
+          <div class="modal-footer">
+              <button type="button" class="btn btn-flat btn-primary center-block" data-dismiss="modal" id="button_confirm_warn_modal">
+                  CLOSE</button>
+          </div>
+      </div>
+      <!-- /.modal-content -->
+  </div>
+  <!-- /.modal-dialog -->
+</div>
+{% endblock %}


### PR DESCRIPTION
This PR presents a new option: `deny_domain_override`. When this option is set to true (ON), users won't be able to create domains if it already exists as a record under an upper domain
For example the user can't create the domain `example.com` if there is a record `example` under `com`