### PR TITLE
Fix API Account deletion

### DIFF
--- a/powerdnsadmin/models/domain.py
+++ b/powerdnsadmin/models/domain.py
@@ -806,7 +806,7 @@ class Domain(db.Model):
         else:
             return {'status': 'error', 'msg': 'This domain does not exist'}
 
-    def assoc_account(self, account_id):
+    def assoc_account(self, account_id, update=True):
         """
         Associate domain with a domain, specified by account id
         """
@@ -842,7 +842,8 @@ class Domain(db.Model):
                 current_app.logger.error(jdata['error'])
                 return {'status': 'error', 'msg': jdata['error']}
             else:
-                self.update()
+                if update:
+                    self.update()
                 msg_str = 'Account changed for domain {0} successfully'
                 current_app.logger.info(msg_str.format(domain_name))
                 return {'status': 'ok', 'msg': 'account changed successfully'}

--- a/powerdnsadmin/routes/api.py
+++ b/powerdnsadmin/routes/api.py
@@ -941,6 +941,18 @@ def api_delete_account(account_id):
     else:
         abort(404)
     current_app.logger.debug(
+            f'Deleting Account {account.name}'
+        )
+
+    # Remove account association from domains first
+    if len(account.domains) > 0:
+        for domain in account.domains:
+            current_app.logger.info(f"Disassociating domain {domain.name} with {account.name}")
+            Domain(name=domain.name).assoc_account(None, update=False)
+        current_app.logger.info("Syncing all domains")
+        Domain().update()
+
+    current_app.logger.debug(
         "Deleting account {} ({})".format(account_id, account.name))
     result = account.delete_account()
     if not result:


### PR DESCRIPTION
Hello,

Since I quickly did a PR with a test branch, I closed it and reopen with a clean one. This patch applies the routine already existing in the GUI. There's a slight change that runs the pdns <> pda domain sync once in the end, rather than for each domain disassociation (if the account owns 20 domains and PDNS has hundreds of domains, the API call could be stuck for many seconds).

Regards
J