### PR TITLE
Pinned compatible itsdangerous version to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ PyYAML==5.4
 Flask-SSLify==0.1.5
 Flask-Mail==0.9.1
 flask-session==0.3.2
+itsdangerous==2.0.1


### PR DESCRIPTION
Fix for issue #1125.

The latest version of itsdangerous (2.1.0) is not compatible with Flask 1.x, therefore the previous version (2.0.1) must be used until the app gets upgraded to Flask 2.x