### PR TITLE
jinja-dependency-fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,5 @@ PyYAML==5.4
 Flask-SSLify==0.1.5
 Flask-Mail==0.9.1
 flask-session==0.3.2
+Jinja2==3.0.3
 itsdangerous==2.0.1


### PR DESCRIPTION
Fix for issue #1146

The importError originates from the fact that [Jinja2 version 3.1.0](https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0) released on 2022-03-24 requires that "Markup and escape should be imported from MarkupSafe" .