### PR TITLE
Fixed werkzeug dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ Flask-Mail==0.9.1
 flask-session==0.3.2
 Jinja2==3.0.3
 itsdangerous==2.0.1
+werkzeug==2.0.3


### PR DESCRIPTION
As mentioned in issue #1150, werkzeug was updated to [3.1.0 ](https://werkzeug.palletsprojects.com/en/2.1.x/changes/#version-2-1-0), dropping support for Python 3.6.