### PR TITLE
fix: Set Content-Type on backend API calls

### DIFF
--- a/powerdnsadmin/models/domain.py
+++ b/powerdnsadmin/models/domain.py
@@ -208,7 +208,7 @@ class Domain(db.Model):
         Add a domain to power dns
         """
 
-        headers = {'X-API-Key': self.PDNS_API_KEY}
+        headers = {'X-API-Key': self.PDNS_API_KEY, 'Content-Type': 'application/json'}
 
         domain_name = domain_name + '.'
         domain_ns = [ns + '.' for ns in domain_ns]
@@ -311,7 +311,7 @@ class Domain(db.Model):
         if not domain:
             return {'status': 'error', 'msg': 'Domain does not exist.'}
 
-        headers = {'X-API-Key': self.PDNS_API_KEY}
+        headers = {'X-API-Key': self.PDNS_API_KEY, 'Content-Type': 'application/json'}
 
         if soa_edit_api not in ["DEFAULT", "INCREASE", "EPOCH", "OFF"]:
             soa_edit_api = 'DEFAULT'
@@ -361,7 +361,7 @@ class Domain(db.Model):
         if not domain:
             return {'status': 'error', 'msg': 'Domain does not exist.'}
 
-        headers = {'X-API-Key': self.PDNS_API_KEY}
+        headers = {'X-API-Key': self.PDNS_API_KEY, 'Content-Type': 'application/json'}
 
         post_data = {"kind": kind, "masters": masters}
 
@@ -681,7 +681,7 @@ class Domain(db.Model):
         """
         domain = Domain.query.filter(Domain.name == domain_name).first()
         if domain:
-            headers = {'X-API-Key': self.PDNS_API_KEY}
+            headers = {'X-API-Key': self.PDNS_API_KEY, 'Content-Type': 'application/json'}
             try:
                 # Enable API-RECTIFY for domain, BEFORE activating DNSSEC
                 post_data = {"api_rectify": True}
@@ -747,7 +747,7 @@ class Domain(db.Model):
         """
         domain = Domain.query.filter(Domain.name == domain_name).first()
         if domain:
-            headers = {'X-API-Key': self.PDNS_API_KEY}
+            headers = {'X-API-Key': self.PDNS_API_KEY, 'Content-Type': 'application/json'}
             try:
                 # Deactivate DNSSEC
                 jdata = utils.fetch_json(
@@ -821,7 +821,7 @@ class Domain(db.Model):
         if not domain:
             return {'status': False, 'msg': 'Domain does not exist'}
 
-        headers = {'X-API-Key': self.PDNS_API_KEY}
+        headers = {'X-API-Key': self.PDNS_API_KEY, 'Content-Type': 'application/json'}
 
         account_name = Account().get_name_by_id(account_id)
 

--- a/powerdnsadmin/models/record.py
+++ b/powerdnsadmin/models/record.py
@@ -99,7 +99,7 @@ class Record(object):
                 }
 
         # Continue if the record is ready to be added
-        headers = {'X-API-Key': self.PDNS_API_KEY}
+        headers = {'X-API-Key': self.PDNS_API_KEY, 'Content-Type': 'application/json'}
 
         try:
             jdata = utils.fetch_json(urljoin(
@@ -293,7 +293,7 @@ class Record(object):
         return new_rrsets, del_rrsets
 
     def apply_rrsets(self, domain_name, rrsets):
-        headers = {'X-API-Key': self.PDNS_API_KEY}
+        headers = {'X-API-Key': self.PDNS_API_KEY, 'Content-Type': 'application/json'}
         jdata = utils.fetch_json(urljoin(
             self.PDNS_STATS_URL, self.API_EXTENDED_URL +
             '/servers/localhost/zones/{0}'.format(domain_name)),
@@ -500,7 +500,7 @@ class Record(object):
         """
         Delete a record from domain
         """
-        headers = {'X-API-Key': self.PDNS_API_KEY}
+        headers = {'X-API-Key': self.PDNS_API_KEY, 'Content-Type': 'application/json'}
         data = {
             "rrsets": [{
                 "name": self.name.rstrip('.') + '.',
@@ -562,7 +562,7 @@ class Record(object):
         """
         Update single record
         """
-        headers = {'X-API-Key': self.PDNS_API_KEY}
+        headers = {'X-API-Key': self.PDNS_API_KEY, 'Content-Type': 'application/json'}
 
         data = {
             "rrsets": [{

--- a/powerdnsadmin/routes/api.py
+++ b/powerdnsadmin/routes/api.py
@@ -188,6 +188,7 @@ def api_login_create_zone():
     api_full_uri = api_uri_with_prefix + '/servers/localhost/zones'
     headers = {}
     headers['X-API-Key'] = pdns_api_key
+    headers['Content-Type'] = 'application/json'
 
     msg_str = "Sending request to powerdns API {0}"
     msg = msg_str.format(request.get_json(force=True))


### PR DESCRIPTION
Improvment for  #1107

PowerDNS Admin can be configure to interact with another PowerDNS Admin instance's API. In such setup, content can't be managed because PowerDNS makes REST calls without setting a Content-Type header. PowerDNS never complains about this, but PowerDNS Admin needs content type.

This PR adds the Content-Type wherever it may be needed.

