### PR TITLE
Fix broken SAML login from 9c00e48f

### DIFF
--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -965,6 +965,7 @@ def saml_authorized():
     if not current_app.config.get('SAML_ENABLED'):
         current_app.logger.error("SAML authentication is disabled.")
         abort(400)
+    from onelogin.saml2.utils import OneLogin_Saml2_Utils
     req = saml.prepare_flask_request(request)
     auth = saml.init_saml_auth(req)
     auth.process_response()


### PR DESCRIPTION
There is a missing local import since the removing of the global import from onelogin.saml2.utils