### PR TITLE
cryptography-dependency-addition

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ flask-session==0.3.2
 Jinja2==3.0.3
 itsdangerous==2.0.1
 werkzeug==2.0.3
+cryptography==36.0.2


### PR DESCRIPTION
Fix for #1179 

cryptography was updated to version 37.0.0, [introducing breaking changes](https://cryptography.io/en/latest/changelog/#v37-0-0). This PR reverts to the latest functioning version 36.0.2.