### PR TITLE
fix: Insert valid JSON in history.detail and replace single quotes in the database

### DIFF
--- a/migrations/versions/fbc7cf864b24_update_history_detail_quotes.py
+++ b/migrations/versions/fbc7cf864b24_update_history_detail_quotes.py
@@ -1,0 +1,47 @@
+"""update history detail quotes
+
+Revision ID: fbc7cf864b24
+Revises: 0967658d9c0d
+Create Date: 2022-05-04 19:49:54.054285
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'fbc7cf864b24'
+down_revision = '0967658d9c0d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    history_table = sa.sql.table(
+        'history',
+        sa.Column('id', sa.Integer),
+        sa.Column('msg', sa.String),
+        sa.Column('detail', sa.Text),
+        sa.Column('created_by', sa.String),
+        sa.Column('created_on', sa.DateTime),
+        sa.Column('domain_id', sa.Integer)
+    )
+
+    op.execute(
+        history_table.update().where(
+            sa.and_(
+                history_table.c.detail.like("%'%"),
+                history_table.c.detail.notlike("%rrests%"),
+                history_table.c.detail.notlike("%rrsets%")
+            )
+        ).values({
+            'detail': sa.func.replace(
+                history_table.c.detail,
+                "'",
+                '"'
+            )
+        })
+    )
+
+
+def downgrade():
+    pass

--- a/powerdnsadmin/models/domain.py
+++ b/powerdnsadmin/models/domain.py
@@ -1,3 +1,4 @@
+import json
 import re
 import traceback
 from flask import current_app
@@ -421,7 +422,7 @@ class Domain(db.Model):
             if result['status'] == 'ok':
                 history = History(msg='Add reverse lookup domain {0}'.format(
                     domain_reverse_name),
-                    detail=str({
+                    detail=json.dumps({
                         'domain_type': 'Master',
                         'domain_master_ips': ''
                     }),

--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -544,7 +544,7 @@ def setting(domain_name):
         history = History(
             msg='Change domain {0} access control'.format(
                 pretty_domain_name(domain_name)),
-            detail=str({'user_has_access': new_user_list}),
+            detail=json.dumps({'user_has_access': new_user_list}),
             created_by=current_user.username,
             domain_id=d.id)
         history.add()
@@ -582,7 +582,7 @@ def change_type(domain_name):
     if status['status'] == 'ok':
         history = History(msg='Update type for domain {0}'.format(
                 pretty_domain_name(domain_name)),
-                          detail=str({
+                          detail=json.dumps({
                               "domain": domain_name,
                               "type": domain_type,
                               "masters": domain_master_ips


### PR DESCRIPTION
#1160 removed some character replacement that are needed for databases with single quotes in the history table. 

Users with such entries in their history are not able to use PDA anymore. This small patch is for testing until a more robust solution is pushed.

Regards