### PR TITLE
Adding venv and yarn-error.log to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,7 @@ node_modules
 powerdnsadmin/static/generated
 .webassets-cache
 .venv*
+venv*
 .pytest_cache
 .DS_Store
+yarn-error.log


### PR DESCRIPTION
venv: in the wiki, the installation is described with creating the venv into "venv", but only ".venv" is in gitignore
yarn-error.log: file is created if yarn fails, it should not be commited to the repo accidentally

This is a preparation for some more pull requests of me soon.