### PR TITLE
Fix rrest typo in history detail

### DIFF
--- a/migrations/versions/6ea7dc05f496_fix_typo_in_history_detail.py
+++ b/migrations/versions/6ea7dc05f496_fix_typo_in_history_detail.py
@@ -1,0 +1,46 @@
+"""Fix typo in history detail
+
+Revision ID: 6ea7dc05f496
+Revises: fbc7cf864b24
+Create Date: 2022-05-10 10:16:58.784497
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6ea7dc05f496'
+down_revision = 'fbc7cf864b24'
+branch_labels = None
+depends_on = None
+
+history_table = sa.sql.table('history',
+                             sa.Column('detail', sa.Text),
+                             )
+
+
+def upgrade():
+    op.execute(
+        history_table.update()
+            .where(history_table.c.detail.like('%"add_rrests":%'))
+            .values({
+                'detail': sa.func.replace(
+                                sa.func.replace(history_table.c.detail, '"add_rrests":', '"add_rrsets":'),
+                                '"del_rrests":', '"del_rrsets":'
+                          )
+            })
+    )
+
+
+def downgrade():
+    op.execute(
+        history_table.update()
+            .where(history_table.c.detail.like('%"add_rrsets":%'))
+            .values({
+                'detail': sa.func.replace(
+                                sa.func.replace(history_table.c.detail, '"add_rrsets":', '"add_rrests":'),
+                                '"del_rrsets":', '"del_rrests":'
+                          )
+            })
+    )

--- a/powerdnsadmin/models/record.py
+++ b/powerdnsadmin/models/record.py
@@ -359,10 +359,10 @@ class Record(object):
 
                     # rollback - re-add the removed record if the adding operation is failed.
                     if del_rrsets["rrsets"]:
-                        rollback_rrests = del_rrsets
+                        rollback_rrsets = del_rrsets
                         for r in del_rrsets["rrsets"]:
                             r['changetype'] = 'REPLACE'
-                        rollback = self.apply_rrsets(domain_name, rollback_rrests)
+                        rollback = self.apply_rrsets(domain_name, rollback_rrsets)
                         if 'error' in rollback.keys():
                             return dict(status='error',
                                         msg='Failed to apply changes. Cannot rollback previous failed operation: {}'

--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -63,7 +63,7 @@ def domain(domain_name):
 
     # Query domain's rrsets from PowerDNS API
     rrsets = Record().get_rrsets(domain.name)
-    current_app.logger.debug("Fetched rrests: \n{}".format(pretty_json(rrsets)))
+    current_app.logger.debug("Fetched rrsets: \n{}".format(pretty_json(rrsets)))
 
     # API server might be down, misconfigured
     if not rrsets and domain.type != 'Slave':
@@ -202,7 +202,7 @@ def changelog(domain_name):
 
     # Query domain's rrsets from PowerDNS API
     rrsets = Record().get_rrsets(domain.name)
-    current_app.logger.debug("Fetched rrests: \n{}".format(pretty_json(rrsets)))
+    current_app.logger.debug("Fetched rrsets: \n{}".format(pretty_json(rrsets)))
 
     # API server might be down, misconfigured
     if not rrsets and domain.type != 'Slave':
@@ -290,7 +290,7 @@ def record_changelog(domain_name, record_name, record_type):
         abort(404)
     # Query domain's rrsets from PowerDNS API
     rrsets = Record().get_rrsets(domain.name)
-    current_app.logger.debug("Fetched rrests: \n{}".format(pretty_json(rrsets)))
+    current_app.logger.debug("Fetched rrsets: \n{}".format(pretty_json(rrsets)))
 
     # API server might be down, misconfigured
     if not rrsets and domain.type != 'Slave':
@@ -328,9 +328,9 @@ def record_changelog(domain_name, record_name, record_type):
     for change_num in changes_set_of_record:
         changes_i = changes_set_of_record[change_num]
         for hre in changes_i: # for each history record entry in changes_i
-            if  'type' in hre.add_rrest and hre.add_rrest['name'] == record_name and hre.add_rrest['type'] == record_type:
+            if  'type' in hre.add_rrset and hre.add_rrset['name'] == record_name and hre.add_rrset['type'] == record_type:
                 continue
-            elif 'type' in hre.del_rrest and hre.del_rrest['name'] == record_name and hre.del_rrest['type'] == record_type:
+            elif 'type' in hre.del_rrset and hre.del_rrset['name'] == record_name and hre.del_rrset['type'] == record_type:
                 continue
             else:
                 changes_set_of_record[change_num].remove(hre)
@@ -450,9 +450,9 @@ def add():
                                     domain_name,
                                     'template':
                                     template.name,
-                                    'add_rrests':
+                                    'add_rrsets':
                                     result['data'][0]['rrsets'],
-                                    'del_rrests':
+                                    'del_rrsets':
                                     result['data'][1]['rrsets']
                                 }),
                             created_by=current_user.username,
@@ -685,8 +685,8 @@ def record_apply(domain_name):
                 msg='Apply record changes to domain {0}'.format(pretty_domain_name(domain_name)),
                 detail = json.dumps({
                         'domain': domain_name,
-                        'add_rrests': result['data'][0]['rrsets'],
-                        'del_rrests': result['data'][1]['rrsets']
+                        'add_rrsets': result['data'][0]['rrsets'],
+                        'del_rrsets': result['data'][1]['rrsets']
                     }),
                 created_by=current_user.username,
                 domain_id=domain.id)

--- a/powerdnsadmin/templates/applied_change_macro.html
+++ b/powerdnsadmin/templates/applied_change_macro.html
@@ -7,28 +7,28 @@
             <th colspan="3">
                 {% if hist_rec_entry.change_type == "+" %}
                 <span
-                    style="background-color:  lightgreen">{{hist_rec_entry.add_rrest['name']}}
-                    {{hist_rec_entry.add_rrest['type']}}</span>
+                    style="background-color:  lightgreen">{{hist_rec_entry.add_rrset['name']}}
+                    {{hist_rec_entry.add_rrset['type']}}</span>
                 {% elif hist_rec_entry.change_type == "-" %}
                 <s
                     style="text-decoration-color: rgba(194, 10,10, 0.6); text-decoration-thickness: 2px;">
-                    {{hist_rec_entry.del_rrest['name']}}
-                    {{hist_rec_entry.del_rrest['type']}}
+                    {{hist_rec_entry.del_rrset['name']}}
+                    {{hist_rec_entry.del_rrset['type']}}
                 </s>
                 {% else %}
-                {{hist_rec_entry.add_rrest['name']}}
-                {{hist_rec_entry.add_rrest['type']}}
+                {{hist_rec_entry.add_rrset['name']}}
+                {{hist_rec_entry.add_rrset['type']}}
                 {% endif %}
 
                 , TTL:
                 {% if "ttl" in hist_rec_entry.changed_fields %}
                 <s
                     style="text-decoration-color: rgba(194, 10,10, 0.6); text-decoration-thickness: 2px;">
-                    {{hist_rec_entry.del_rrest['ttl']}}</s>
+                    {{hist_rec_entry.del_rrset['ttl']}}</s>
                 <span
-                    style="background-color:  lightgreen">{{hist_rec_entry.add_rrest['ttl']}}</span>
+                    style="background-color:  lightgreen">{{hist_rec_entry.add_rrset['ttl']}}</span>
                 {% else %}
-                {{hist_rec_entry.add_rrest['ttl']}}
+                {{hist_rec_entry.add_rrset['ttl']}}
                 {% endif %}
 
             </th>
@@ -120,7 +120,7 @@
                 </table>
             </td>
             <td>
-                {% for comments in hist_rec_entry.add_rrest['comments'] %}
+                {% for comments in hist_rec_entry.add_rrset['comments'] %}
                 {{comments['content'] }}
                 <br/>
                 {% endfor %}


### PR DESCRIPTION
There is a misspelling of rrset throughout the history logic, which also effects the json payload in the `history` database table. The migration will fix the existing payloads, so there is no need for backwards-compatibility and the code-change is a simple search-and-replace.

I am not really happy with the migration, but it is the best I could come up with to modify the json payload in a database-agnostic manner. Any suggestion are welcome.