### PR TITLE
Small fixes to SAML service

### DIFF
--- a/configs/development.py
+++ b/configs/development.py
@@ -148,6 +148,10 @@ SAML_ENABLED = False
 
 # #SAML_ASSERTION_ENCRYPTED = True
 
+# Some IdPs, like Okta, do not return Attribute Statements by default
+# Set the following to False if you are using Okta and not manually configuring Attribute Statements
+# #SAML_WANT_ATTRIBUTE_STATEMENT = True
+
 # Remote authentication settings
 
 # Whether to enable remote user authentication or not

--- a/configs/development.py
+++ b/configs/development.py
@@ -133,8 +133,8 @@ SAML_ENABLED = False
 # CAUTION: For production use, usage of self-signed certificates it's highly discouraged.
 # Use certificates from trusted CA instead
 # ###########################################################################################
-# SAML_CERT_FILE = '/etc/pki/powerdns-admin/cert.crt'
-# SAML_CERT_KEY = '/etc/pki/powerdns-admin/key.pem'
+# SAML_CERT = '/etc/pki/powerdns-admin/cert.crt'
+# SAML_KEY = '/etc/pki/powerdns-admin/key.pem'
 
 # Configures if SAML tokens should be encrypted.
 # SAML_SIGN_REQUEST = False

--- a/configs/development.py
+++ b/configs/development.py
@@ -120,6 +120,16 @@ SAML_ENABLED = False
 # ###  be created and the user added to them.
 # SAML_ATTRIBUTE_ACCOUNT = 'https://example.edu/pdns-account'
 
+# ## Attribute name that aggregates group names
+# ### Default: Don't collect IdP groups from SAML group attributes
+# ### In Okta, you can assign administrators by group using "Group Attribute Statements."
+# ### In this case, the SAML_ATTRIBUTE_GROUP will be the attribute name for a collection of
+# ###  groups passed in the SAML assertion.  From there, you can specify a SAML_GROUP_ADMIN_NAME.
+# ### If the user is a member of this group, and that group name is included in the collection,
+# ###   the user will be set as an administrator.
+# #SAML_ATTRIBUTE_GROUP = 'https://example.edu/pdns-groups'
+# #SAML_GROUP_ADMIN_NAME = 'PowerDNSAdmin-Administrators'
+
 # SAML_SP_ENTITY_ID = 'http://<SAML SP Entity ID>'
 # SAML_SP_CONTACT_NAME = '<contact name>'
 # SAML_SP_CONTACT_MAIL = '<contact mail>'

--- a/powerdnsadmin/services/saml.py
+++ b/powerdnsadmin/services/saml.py
@@ -72,8 +72,9 @@ class SAML(object):
     def prepare_flask_request(self, request):
         # If server is behind proxys or balancers use the HTTP_X_FORWARDED fields
         url_data = urlparse(request.url)
+        proto = request.headers.get('HTTP_X_FORWARDED_PROTO', request.scheme)
         return {
-            'https': 'on' if request.scheme == 'https' else 'off',
+            'https': 'on' if proto == 'https' else 'off',
             'http_host': request.host,
             'server_port': url_data.port,
             'script_name': request.path,

--- a/powerdnsadmin/services/saml.py
+++ b/powerdnsadmin/services/saml.py
@@ -163,7 +163,8 @@ class SAML(object):
             'signatureAlgorithm'] = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
         settings['security']['wantAssertionsEncrypted'] = current_app.config.get(
             'SAML_ASSERTION_ENCRYPTED', True)
-        settings['security']['wantAttributeStatement'] = True
+        settings['security']['wantAttributeStatement'] = current_app.config.get(
+            'SAML_WANT_ATTRIBUTE_STATEMENT', True)
         settings['security']['wantNameId'] = True
         settings['security']['authnRequestsSigned'] = current_app.config[
             'SAML_SIGN_REQUEST']


### PR DESCRIPTION
This PR addresses four issues with the SAML service:

1. The example `development.py` config had incorrect labels for `SAML_CERT` and `SAML_KEY`
2. For users getting started with a simple proof-of-concept, not having to configure AttributeStatements on the IdP side would be helpful.  To make it easier, `SAML_WANT_ATTRIBUTE_STATEMENT` should probably default to `False`, but at least having it exposed in the config with an explanation will go a long way for beginners.
3. The current SAML service does not work when run with gunicorn behind an SSL proxy web server.  All of the relay, and response URLs end up hard-coded with `http://`.  Taking a hint from the comment in the `prepare_flask_request` method, we use the proxy HTTP headers to tell us if we should build the URLs with `http://` or `'https://`.  (I also updated the nginx example in the wiki to include the `X-Forwarded-Proto` header so this will work out of the box for users.  
4. Using `SAML_ATTRIBUTE_GROUP` in combination with `SAML_GROUP_ADMIN_NAME` is an excellent method for elevating users to admin by group membership from the SAML assertion.  Added documentation in the `development.py` config to help users get started with this approach.