### PR TITLE
Modification to SAML groups and group management

### DIFF
--- a/configs/development.py
+++ b/configs/development.py
@@ -113,6 +113,14 @@ SAML_ENABLED = False
 # ###  the user is set as a non-administrator user.
 # #SAML_ATTRIBUTE_ADMIN = 'https://example.edu/pdns-admin'
 
+## Attribute to get admin status for groups with the IdP
+# ### Default: Don't set administrator group with SAML attributes
+#SAML_GROUP_ADMIN_NAME = 'GroupName'
+
+## Attribute to get operator status for groups with the IdP
+# ### Default: Don't set operator group with SAML attributes
+#SAML_GROUP_OPERATOR_NAME = 'GroupName'
+
 # ## Attribute to get account names from
 # ### Default: Don't control accounts with SAML attribute
 # ### If set, the user will be added and removed from accounts to match

--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -1008,6 +1008,8 @@ def saml_authorized():
                                                       None)
         admin_group_name = current_app.config.get('SAML_GROUP_ADMIN_NAME',
                                                   None)
+        operator_group_name = current_app.config.get('SAML_GROUP_OPERATOR_NAME',
+                                                  None)
         group_to_account_mapping = create_group_to_account_mapping()
 
         if email_attribute_name in session['samlUserdata']:
@@ -1061,6 +1063,8 @@ def saml_authorized():
             uplift_to_admin(user)
         elif admin_group_name in user_groups:
             uplift_to_admin(user)
+        elif operator_group_name in user_groups:
+            uplift_to_operator(user)
         elif admin_attribute_name or group_attribute_name:
             if user.role.name != 'User':
                 user.role_id = Role.query.filter_by(name='User').first().id
@@ -1113,6 +1117,14 @@ def uplift_to_admin(user):
     if user.role.name != 'Administrator':
         user.role_id = Role.query.filter_by(name='Administrator').first().id
         history = History(msg='Promoting {0} to administrator'.format(
+            user.username),
+                          created_by='SAML Assertion')
+        history.add()
+
+def uplift_to_operator(user):
+    if user.role.name != 'Operator':
+        user.role_id = Role.query.filter_by(name='Operator').first().id
+        history = History(msg='Promoting {0} to operator'.format(
             user.username),
                           created_by='SAML Assertion')
         history.add()


### PR DESCRIPTION
Added code in the index.py to not only pull the admin_user_group but also an operator_user_group. We then use this to assign those respective levels of access in PDNS-Admin, this means all we need to do is create a new user in JumpCloud and add them to the right group and they can log in without any need to tweak permissions in PDNS-Admin itself.