### PR TITLE
Fix DynDNS2 using X-Forwarded-For

### DIFF
--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -836,7 +836,7 @@ def dyndns_update():
 
     remote_addr = utils.validate_ipaddress(
         request.headers.get('X-Forwarded-For',
-                            request.remote_addr).split(', ')[:1])
+                            request.remote_addr).split(', ')[0])
 
     response = 'nochg'
     for ip in myip_addr or remote_addr:


### PR DESCRIPTION
When a DynDNS request is submitted with an empty myip argument, and an X-Forwarded-For HTTP header is present, nothing is done. This fixes the issue.
