### PR TITLE
Improve performance of domain update

### DIFF
--- a/powerdnsadmin/models/domain.py
+++ b/powerdnsadmin/models/domain.py
@@ -143,9 +143,20 @@ class Domain(db.Model):
                 current_app.logger.debug(traceback.format_exc())
 
             # update/add new domain
+            account_cache = {}
             for data in jdata:
                 if 'account' in data:
-                    account_id = Account().get_id_by_name(data['account'])
+                    # if no account is set don't try to query db
+                    if data['account'] == '':
+                        find_account_id = None
+                    else:
+                        find_account_id = account_cache.get(data['account'])
+                        # if account was not queried in the past and hence not in cache
+                        if find_account_id is None:
+                            find_account_id = Account().get_id_by_name(data['account'])
+                            # add to cache
+                            account_cache[data['account']] = find_account_id
+                    account_id = find_account_id
                 else:
                     current_app.logger.debug(
                         "No 'account' data found in API result - Unsupported PowerDNS version?"


### PR DESCRIPTION
* Previously the loop would always query the db even for none existing accounts
* Now cache previously looked up accounts and skip db queries for empty accounts

Loop time previously: 3.000699043273926 sec
Loop time now: 0.2798025608062744 sec