### PR TITLE
Allow new domains to be absolute

### DIFF
--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -363,6 +363,9 @@ def add():
                     'errors/400.html',
                     msg="Please enter a valid domain name"), 400
 
+            if domain_name.endswith('.'):
+                domain_name = domain_name[:-1]
+
             # If User creates the domain, check some additional stuff
             if current_user.role.name not in ['Administrator', 'Operator']:
                 # Get all the account_ids of the user


### PR DESCRIPTION
Allow the new domain name to be input absolute (with a dot at the end). To keep the rest of the logic working as-is, remove it fairly early in the function.

Would have loved to use `str.removesuffix()` but that's python v3.9+ only.