### PR TITLE
Update to python-ldap 3.4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ mysqlclient==2.0.1
 configobj==5.0.6
 bcrypt>=3.1.7
 requests==2.24.0
-python-ldap==3.4.0
+python-ldap==3.4.2
 pyotp==2.4.0
 qrcode==6.1
 dnspython>=1.16.0


### PR DESCRIPTION
Minor version bump. This is necessary to resolve build issues on Alpine 3.15+ or other OpenLDAP 2.5+ distributions.

When attempting to build with 3.4.0 on Alpine 3.15+ or any distribution using OpenLDAP 2.5+ (which should be all of them as OpenLDAP 2.4 is fully end of life,) the build of python-ldap will fail due to the python-ldap maintainers requiring re-entrant OpenLDAP and previously insisting users fix it by simply installing a totally different distribution.
python-ldap 3.4.2 finally saw the light and implemented a proper fix which handles both 2.4 and 2.5+.

Tested locally on Alpine 3.16.1, Rocky 8.5, and RHEL7 using a virtual environment, did not run into any issues.