### PR TITLE
routes/index.py: otp_force shouldn't apply to OAuth

### DIFF
--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -580,7 +580,7 @@ def get_azure_groups(uri):
 def authenticate_user(user, authenticator, remember=False):
     login_user(user, remember=remember)
     signin_history(user.username, authenticator, True)
-    if Setting().get('otp_force') and Setting().get('otp_field_enabled') and not user.otp_secret:
+    if Setting().get('otp_force') and Setting().get('otp_field_enabled') and not user.otp_secret and session['authentication_type'] not in ['OAuth']:
         user.update_profile(enable_otp=True)
         user_id = current_user.id
         prepare_welcome_user(user_id)


### PR DESCRIPTION
as 2FA policies are typically enforced on the OAuth proviers end

Relates to #1051