### PR TITLE
models/user.py: add non-zero valid_window to totp.verify

### DIFF
--- a/powerdnsadmin/models/user.py
+++ b/powerdnsadmin/models/user.py
@@ -94,7 +94,7 @@ class User(db.Model):
 
     def verify_totp(self, token):
         totp = pyotp.TOTP(self.otp_secret)
-        return totp.verify(token)
+        return totp.verify(token, valid_window = 5)
 
     def get_hashed_password(self, plain_text_password=None):
         # Hash a password for the first time


### PR DESCRIPTION
PyOTP's totp.verify defaults to the valid_window of zero, which means it will reject valid codes, if submitted just past the 30 sec window. It also means, users will run into authentication issues very quickly if their phones time-sync isn't perfect.

Therefore valid_window should at the very least be 1 or more, settting it higher trades security for robustness, especially with regard to time desync issues.