### PR TITLE
Fix order of operations in api payload

### DIFF
--- a/powerdnsadmin/models/record.py
+++ b/powerdnsadmin/models/record.py
@@ -337,7 +337,8 @@ class Record(object):
         replaces = [replace_for_api(r) for r in new_rrsets]
         deletes = [delete_for_api(r) for r in del_rrsets if not rrset_in(r, replaces)]
         return {
-            'rrsets': replaces + deletes
+            # order matters: first deletions, then additions+changes
+            'rrsets': deletes + replaces
         }
 
     def apply(self, domain_name, submitted_records):


### PR DESCRIPTION
PDNS checks that when a `CNAME` rrset is created that no other rrset of the same name but a different rtype exists. When changing a record type to `CNAME`, PDA will send two operations in one api call to PDNS: A deletion of the old rrset, and the addition of the new rrset. For the check in PDNS to pass, the deletion needs to happen before the addition. Before PR #1201 that was the case, the first api call did deletions and the second handled additions and changes. Currently the api payload contains additions first and deletions last. PDNS applies these in the order they are passed in the payload to the api, so to restore the original/correct/working behaviour the order of operations in the api payload has to be reversed.

fixes #1251