### PR TITLE
Allow newer PyYAML version to support Python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ bravado-core==5.17.0
 lima==0.5
 pytest==6.1.1
 pytimeparse==1.1.8
-PyYAML==5.4
+PyYAML>=5.4
 Flask-SSLify==0.1.5
 Flask-Mail==0.9.1
 flask-session==0.3.2


### PR DESCRIPTION
With PyYAML I'm getting the following error on Python 3.10 during the installation:

```
Collecting PyYAML==5.4
  Downloading PyYAML-5.4.tar.gz (174 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 174.8/174.8 kB 16.0 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      /tmp/pip-build-env-blbkkdhq/overlay/lib/python3.10/site-packages/setuptools/config/setupcfg.py:508: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
        warnings.warn(msg, warning_class)
      running egg_info
      writing lib3/PyYAML.egg-info/PKG-INFO
      writing dependency_links to lib3/PyYAML.egg-info/dependency_links.txt
      writing top-level names to lib3/PyYAML.egg-info/top_level.txt
      failed to import Cython: /tmp/pip-build-env-blbkkdhq/overlay/lib/python3.10/site-packages/Cython/Compiler/Scanning.cpython-310-x86_64-linux-gnu.so: failed to map segment from shared object
      error: Cython does not appear to be installed
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.
```

This passes with the code change from this commit:

```
Collecting PyYAML>=5.4
  Downloading PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (682 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 682.2/682.2 kB 16.2 MB/s eta 0:00:00
```