### PR TITLE
allow null/None JSON data (Used for pdns notifies via api and by LEGO-ACME v 4.9.0)

### DIFF
--- a/powerdnsadmin/lib/helper.py
+++ b/powerdnsadmin/lib/helper.py
@@ -14,9 +14,9 @@ def forward_request():
     msg_str = "Sending request to powerdns API {0}"
 
     if request.method != 'GET' and request.method != 'DELETE':
-        msg = msg_str.format(request.get_json(force=True))
+        msg = msg_str.format(request.get_json(force=True, silent=True))
         current_app.logger.debug(msg)
-        data = request.get_json(force=True)
+        data = request.get_json(force=True, silent=True)
 
     verify = False
 


### PR DESCRIPTION
This change permits to proxy pdns zone notify api requests (which are expected to be with empty body)

[pdns api reference](https://doc.powerdns.com/authoritative/http-api/zone.html#put--servers-server_id-zones-zone_id-notify)

Solves #1265