### PR TITLE
Fix handling of passwords with % in the SQLALCHEMY_DATABASE_URI

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -19,7 +19,7 @@ logger = logging.getLogger('alembic.env')
 # target_metadata = mymodel.Base.metadata
 from flask import current_app
 config.set_main_option('sqlalchemy.url',
-                       current_app.config.get('SQLALCHEMY_DATABASE_URI'))
+                       current_app.config.get('SQLALCHEMY_DATABASE_URI').replace("%","%%"))
 target_metadata = current_app.extensions['migrate'].db.metadata
 
 # other values from the config, defined by the needs of env.py,


### PR DESCRIPTION
Fix Flask-Migrate ValueError from occurring when a password has '%' characters in it when specified via SQLALCHEMY_DATABASE_URI.

This resolves the issue described (and the solution from) [here](https://stackoverflow.com/questions/39849641/in-flask-migrate-valueerror-invalid-interpolation-syntax-in-connection-string-a).

% characters in the password need to be properly escaped, but only in the migrate script and not elsewhere. Tested and deployed this fix on my own deployment where it was necessary due to the use of auto-generated passwords on K8S.