### PR TITLE
Update history extend history message

### DIFF
--- a/powerdnsadmin/models/history.py
+++ b/powerdnsadmin/models/history.py
@@ -9,7 +9,7 @@ from .base import db
 class History(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     # format of msg field must not change. History traversing is done using part of the msg field
-    msg = db.Column(db.String(256))
+    msg = db.Column(db.String(1024))
     # detail = db.Column(db.Text().with_variant(db.Text(length=2**24-2), 'mysql'))
     detail = db.Column(db.Text())
     created_by = db.Column(db.String(128))


### PR DESCRIPTION
Some large zones need more large record history msg size because msg(256) was truncated and missing records audit.