### PR TITLE
Removed mysqlclient from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ Flask-Login==0.5.0
 Flask-SQLAlchemy==2.4.4
 Flask-Migrate==2.5.3
 SQLAlchemy==1.3.19
-mysqlclient==2.0.1
 configobj==5.0.6
 bcrypt>=3.1.7
 requests==2.24.0


### PR DESCRIPTION
Removed mysqlclient from requirements.txt based on [issue 1305](https://github.com/PowerDNS-Admin/PowerDNS-Admin/issues/1305). Wiki documentation has already been updated to reflect this change.