### PR TITLE
Draft: Fix pyhton-ldap upgrade

### DIFF
--- a/powerdnsadmin/models/user.py
+++ b/powerdnsadmin/models/user.py
@@ -125,7 +125,6 @@ class User(db.Model):
         conn = ldap.initialize(Setting().get('ldap_uri'))
         conn.set_option(ldap.OPT_REFERRALS, ldap.OPT_OFF)
         conn.set_option(ldap.OPT_PROTOCOL_VERSION, 3)
-        conn.set_option(ldap.OPT_X_TLS, ldap.OPT_X_TLS_DEMAND)
         conn.set_option(ldap.OPT_X_TLS_DEMAND, True)
         conn.set_option(ldap.OPT_DEBUG_LEVEL, 255)
         conn.protocol_version = ldap.VERSION3


### PR DESCRIPTION
This should work. It needs to be tested on a StartTLS setup as well.

I guess that these settings aren't even applied, as the [documentation says](https://www.python-ldap.org/en/python-ldap-3.4.2/reference/ldap.html#tls-options) that we have to call ldap.OPT_X_TLS_NEWCTX to make all the configurations effective, and it is not the case apparently.

At least, if removing this setting is harmless, it could be a quick fixup.