### PR TITLE
Fix #1329

### DIFF
--- a/powerdnsadmin/models/user.py
+++ b/powerdnsadmin/models/user.py
@@ -108,8 +108,9 @@ class User(db.Model):
     def check_password(self, hashed_password):
         # Check hashed password. Using bcrypt, the salt is saved into the hash itself
         if hasattr(self, "plain_text_password"):
-            return bcrypt.checkpw(self.plain_text_password.encode('utf-8'),
-                                  hashed_password.encode('utf-8'))
+            if self.plain_text_password != None:
+                return bcrypt.checkpw(self.plain_text_password.encode('utf-8'),
+                                     hashed_password.encode('utf-8'))
         return False
 
     def get_user_info_by_id(self):
@@ -422,8 +423,12 @@ class User(db.Model):
             self.role_id = Role.query.filter_by(
                 name='Administrator').first().id
 
-        self.password = self.get_hashed_password(
-            self.plain_text_password) if hasattr(self, "plain_text_password") else '*'
+        if hasattr(self, "plain_text_password"):
+            if self.plain_text_password != None:
+                self.password = self.get_hashed_password(
+                    self.plain_text_password)
+        else:
+            self.password = '*'
 
         if self.password and self.password != '*':
             self.password = self.password.decode("utf-8")
@@ -460,8 +465,9 @@ class User(db.Model):
 
         # store new password hash (only if changed)
         if hasattr(self, "plain_text_password"):
-            user.password = self.get_hashed_password(
-                self.plain_text_password).decode("utf-8")
+            if self.plain_text_password != None:
+                user.password = self.get_hashed_password(
+                    self.plain_text_password).decode("utf-8")
 
         db.session.commit()
         return {'status': True, 'msg': 'User updated successfully'}
@@ -476,9 +482,11 @@ class User(db.Model):
 
         user.firstname = self.firstname if self.firstname else user.firstname
         user.lastname = self.lastname if self.lastname else user.lastname
-        user.password = self.get_hashed_password(
-            self.plain_text_password).decode(
-                "utf-8") if hasattr(self, "plain_text_password") else user.password
+
+        if hasattr(self, "plain_text_password"):
+            if self.plain_text_password != None:
+                user.password = self.get_hashed_password(
+                 self.plain_text_password).decode("utf-8")
 
         if self.email:
             # Can not update to a new email that


### PR DESCRIPTION
Quick and dirty - but fixes #1329.

From @BluemediaGER's fantastic breakdown:

> I tracked this issue down to commit [4fd1b10](https://github.com/PowerDNS-Admin/PowerDNS-Admin/commit/4fd1b1001847eaef73b3da9a222c011068a3b2b7). The new code uses `hasattr()` to check if `plain_text_password` exists:
> 
> https://github.com/PowerDNS-Admin/PowerDNS-Admin/blob/4fd1b1001847eaef73b3da9a222c011068a3b2b7/powerdnsadmin/models/user.py#L461-L464
> 
> 
> But `plain_text_password` always exists. It's `None` if not set otherwise. This leads to `hasattr()` always returning `True`, which in turn runs the code inside the if statement with invalid input.
> Calling `get_hashed_password()` returns `plain_text_password` if it's `None`. So effectively the function returns `None` in this case:
> 
> https://github.com/PowerDNS-Admin/PowerDNS-Admin/blob/4fd1b1001847eaef73b3da9a222c011068a3b2b7/powerdnsadmin/models/user.py#L99-L106
> 
> 
> This leads to `update_local_user()` effectively trying to call `None.decode()`.
> https://github.com/PowerDNS-Admin/PowerDNS-Admin/blob/4fd1b1001847eaef73b3da9a222c011068a3b2b7/powerdnsadmin/models/user.py#L463-L464

Adding a nested `if self.plain_text_password != None` maintains the protections added by the above commit but then, once it's confirmed to exist, checks that it isn't just `None` - stopping it from running `None.decode()`.