### PR TITLE
Support pdns4.7

### DIFF
--- a/migrations/versions/f41520e41cee_update_domain_type_length.py
+++ b/migrations/versions/f41520e41cee_update_domain_type_length.py
@@ -1,0 +1,31 @@
+"""update domain type length
+
+Revision ID: f41520e41cee
+Revises: 6ea7dc05f496
+Create Date: 2023-01-10 11:56:28.538485
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f41520e41cee'
+down_revision = '6ea7dc05f496'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('domain') as batch_op:
+        batch_op.alter_column('type',
+                              existing_type=sa.String(length=6),
+                              type_=sa.String(length=8))
+
+
+def downgrade():
+    with op.batch_alter_table('domain') as batch_op:
+        batch_op.alter_column('type',
+                              existing_type=sa.String(length=8),
+                              type_=sa.String(length=6))
+        

--- a/powerdnsadmin/models/domain.py
+++ b/powerdnsadmin/models/domain.py
@@ -20,7 +20,7 @@ class Domain(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(255), index=True, unique=True)
     master = db.Column(db.String(128))
-    type = db.Column(db.String(6), nullable=False)
+    type = db.Column(db.String(8), nullable=False)
     serial = db.Column(db.BigInteger)
     notified_serial = db.Column(db.BigInteger)
     last_check = db.Column(db.Integer)


### PR DESCRIPTION
PowerDNS 4.7 is supporting 2 new zone types: "producer" & "consumer"
Due to the domain type is limited to 6 chars, PDA zone update will fail if producer or cusomer zones exist.
To solve this problem, this PR increases the lenght of the domain type to 8 chars.

This PR is the first step to support Catalog Zones in PDA (#1348)