### PR TITLE
Use SITE_NAME as title

### DIFF
--- a/powerdnsadmin/templates/base.html
+++ b/powerdnsadmin/templates/base.html
@@ -32,7 +32,13 @@
       <!-- mini logo for sidebar mini 50x50 pixels -->
       <span class="logo-mini"><b>PD</b>A</span>
       <!-- logo for regular state and mobile devices -->
-      <span class="logo-lg"><b>PowerDNS</b>-Admin</span>
+      <span class="logo-lg">
+        {% if SETTING.get('site_name') %}
+          <b>{{ SITE_NAME }}</b>
+        {% else %}
+          <b>PowerDNS</b>-Admin
+        {% endif %}
+      </span>
     </a>
     <!-- Header Navbar: style can be found in header.less -->
     <nav class="navbar navbar-static-top">

--- a/powerdnsadmin/templates/login.html
+++ b/powerdnsadmin/templates/login.html
@@ -20,7 +20,13 @@
 <body class="hold-transition login-page">
   <div class="login-box">
     <div class="login-logo">
-      <a href="{{ url_for('index.index') }}"><b>{{ SITE_NAME }}</b></a>
+      <a href="{{ url_for('index.index') }}">
+        {% if SETTING.get('site_name') %}
+          <b>{{ SITE_NAME }}</b>
+        {% else %}
+          <b>PowerDNS</b>-Admin
+        {% endif %}
+      </a>
     </div>
     <!-- /.login-logo -->
     <div class="login-box-body">


### PR DESCRIPTION
Use SITE_NAME for upper left title on base page and login box title on login page (with default value).
This can be useful when using multiple powerdns admin in an organization.