### PR TITLE
Changed auto_ptr() logic to remove-then-add

### DIFF
--- a/powerdnsadmin/models/record.py
+++ b/powerdnsadmin/models/record.py
@@ -422,6 +422,25 @@ class Record(object):
                 ]
 
                 d = Domain()
+                for r in del_rrsets:
+                    for record in r['records']:
+                        # Format the reverse record name
+                        # It is the reverse of forward record's content.
+                        reverse_host_address = dns.reversename.from_address(
+                            record['content']).to_text()
+
+                        # Create the reverse domain name in PDNS
+                        domain_reverse_name = d.get_reverse_domain_name(
+                            reverse_host_address)
+                        d.create_reverse_domain(domain_name,
+                                                domain_reverse_name)
+
+                        # Delete the reverse zone
+                        self.name = reverse_host_address
+                        self.type = 'PTR'
+                        self.data = record['content']
+                        self.delete(domain_reverse_name)
+                
                 for r in new_rrsets:
                     for record in r['records']:
                         # Format the reverse record name
@@ -455,25 +474,6 @@ class Record(object):
                         # Format the rrset
                         rrset = {"rrsets": rrset_data}
                         self.add(domain_reverse_name, rrset)
-
-                for r in del_rrsets:
-                    for record in r['records']:
-                        # Format the reverse record name
-                        # It is the reverse of forward record's content.
-                        reverse_host_address = dns.reversename.from_address(
-                            record['content']).to_text()
-
-                        # Create the reverse domain name in PDNS
-                        domain_reverse_name = d.get_reverse_domain_name(
-                            reverse_host_address)
-                        d.create_reverse_domain(domain_name,
-                                                domain_reverse_name)
-
-                        # Delete the reverse zone
-                        self.name = reverse_host_address
-                        self.type = 'PTR'
-                        self.data = record['content']
-                        self.delete(domain_reverse_name)
                 return {
                     'status': 'ok',
                     'msg': 'Auto-PTR record was updated successfully'


### PR DESCRIPTION
This merge request aims to fix a bug that exists in the auto_ptr logic.

The bug is that PowerDNS-Admin deletes PTR records when a user edits an A record without changing the name and content fields.

### Steps to Reproduce

1. Find an existing A/PTR record pair. e.g. "www  in zone example.org -> 5.5.5.5" and "5 in zone 5.5.5.in-addr.arpa PTR www.example.com"
2. Edit the A record without changing the name or content, i.e. edit the comments or TTL fields.
3. Save and apply

### Expected behaviour

The PTR record is still present after the changes are applied.

### Observed behaviour

The PTR record is removed from the authoritative server.

### Proposed fix

The current behaviour of the auto_ptr function is to (re)add the corresponding PTR record, and then immediately delete it, leaving the reverse zone without the desired PTR record.

With the proposed fix, the order of operations is reversed, i.e. the old record is first deleted and only then are new records added. Thus, at the end of the operation the PTR is still present.

