### PR TITLE
Global Search available for all users

### DIFF
--- a/powerdnsadmin/templates/base.html
+++ b/powerdnsadmin/templates/base.html
@@ -85,6 +85,12 @@
                             <p>Dashboard</p>
                         </a>
                     </li>
+                    <li class="{{ 'nav-item active' if active_page == 'admin_global_search' else 'nav-item' }}">
+                        <a href="{{ url_for('admin.global_search') }}" class="nav-link">
+                            <i class="nav-icon fa-solid fa-search"></i>
+                            <p>Global Search</p>
+                        </a>
+                    </li>
                     {% if SETTING.get('allow_user_create_domain') or current_user.role.name in ['Administrator', 'Operator'] %}
                         <li class="{{ 'nav-item active' if active_page == 'nav-item new_domain' else 'nav-item' }}">
                             <a href="{{ url_for('domain.add') }}" class="nav-link">
@@ -113,12 +119,6 @@
                             <a href="{{ url_for('admin.server_configuration') }}" class="nav-link">
                                 <i class="nav-icon fa-solid fa-cog"></i>
                                 <p>Server Configuration</p>
-                            </a>
-                        </li>
-                        <li class="{{ 'nav-item active' if active_page == 'admin_global_search' else 'nav-item' }}">
-                            <a href="{{ url_for('admin.global_search') }}" class="nav-link">
-                                <i class="nav-icon fa-solid fa-search"></i>
-                                <p>Global Search</p>
                             </a>
                         </li>
                         <li class="{{ 'nav-item active' if active_page == 'admin_history' else 'nav-item' }}">


### PR DESCRIPTION
Introducing Global Search feature for standard users too. As the API search call has no restriction, the results are filtered by allowed domain list for standard users. If standard user has a lot of domains to manage, this feature is a must have.
Operators/administrators search results won't be filtered.