### PR TITLE
Fix dashboard MySQL performance with large history for standard users

### DIFF
--- a/powerdnsadmin/routes/dashboard.py
+++ b/powerdnsadmin/routes/dashboard.py
@@ -166,6 +166,7 @@ def dashboard():
         history = History.query.order_by(History.created_on.desc()).limit(4).all()
     elif Setting().get('allow_user_view_history'):
         history = db.session.query(History) \
+            .with_hint(History, "FORCE INDEX (ix_history_created_on)", 'mysql') \
             .join(Domain, History.domain_id == Domain.id) \
             .outerjoin(DomainUser, Domain.id == DomainUser.domain_id) \
             .outerjoin(Account, Domain.account_id == Account.id) \
@@ -175,9 +176,19 @@ def dashboard():
             db.or_(
                 DomainUser.user_id == current_user.id,
                 AccountUser.user_id == current_user.id
-            )).all()
-        history_number = len(history)  # history.count()
-        history = history[:4]
+            )) \
+            .limit(4) \
+            .all()
+        history_number = db.session.query(History) \
+            .join(Domain, History.domain_id == Domain.id) \
+            .outerjoin(DomainUser, Domain.id == DomainUser.domain_id) \
+            .outerjoin(Account, Domain.account_id == Account.id) \
+            .outerjoin(AccountUser, Account.id == AccountUser.account_id) \
+            .filter(
+            db.or_(
+                DomainUser.user_id == current_user.id,
+                AccountUser.user_id == current_user.id
+            )).count()
         domain_count = db.session.query(Domain) \
             .outerjoin(DomainUser, Domain.id == DomainUser.domain_id) \
             .outerjoin(Account, Domain.account_id == Account.id) \

--- a/powerdnsadmin/routes/dashboard.py
+++ b/powerdnsadmin/routes/dashboard.py
@@ -165,30 +165,24 @@ def dashboard():
         history_number = History.query.count()
         history = History.query.order_by(History.created_on.desc()).limit(4).all()
     elif Setting().get('allow_user_view_history'):
-        history = db.session.query(History) \
-            .with_hint(History, "FORCE INDEX (ix_history_created_on)", 'mysql') \
-            .join(Domain, History.domain_id == Domain.id) \
+        allowed_domain_id_subquery = db.session.query(Domain.id) \
             .outerjoin(DomainUser, Domain.id == DomainUser.domain_id) \
             .outerjoin(Account, Domain.account_id == Account.id) \
             .outerjoin(AccountUser, Account.id == AccountUser.account_id) \
-            .order_by(History.created_on.desc()) \
-            .filter(
-            db.or_(
+            .filter(db.or_(
                 DomainUser.user_id == current_user.id,
                 AccountUser.user_id == current_user.id
             )) \
+        .subquery()
+        history = db.session.query(History) \
+            .with_hint(History, "FORCE INDEX (ix_history_created_on)", 'mysql') \
+            .order_by(History.created_on.desc()) \
+            .filter(History.domain_id.in_(allowed_domain_id_subquery)) \
             .limit(4) \
             .all()
         history_number = db.session.query(History) \
-            .join(Domain, History.domain_id == Domain.id) \
-            .outerjoin(DomainUser, Domain.id == DomainUser.domain_id) \
-            .outerjoin(Account, Domain.account_id == Account.id) \
-            .outerjoin(AccountUser, Account.id == AccountUser.account_id) \
-            .filter(
-            db.or_(
-                DomainUser.user_id == current_user.id,
-                AccountUser.user_id == current_user.id
-            )).count()
+            .filter(History.domain_id.in_(allowed_domain_id_subquery)) \
+            .count()
         domain_count = db.session.query(Domain) \
             .outerjoin(DomainUser, Domain.id == DomainUser.domain_id) \
             .outerjoin(Account, Domain.account_id == Account.id) \


### PR DESCRIPTION
Stumbled into severe dashboard performance issue, when the following requirements are met:
- history table is big (e.g. 450k records)
- database engine is MySQL
- after login only standard user privileges are granted

MySQL isn't using indexes properly when joining large tables and "sort by" is causing massive filesort.  It isn't ok to fetch 175MB of data from mySQL to count the rows in python. Dashboard data fetching is split to two queries and by forcing "with index" for mysql, the execution was improved from 10 seconds to fractions of second.

```
# Query_time: 10.360052  Lock_time: 0.000002  Rows_sent: 447869  Rows_examined: 1793977  Rows_affected: 0  Bytes_sent: 174179066
use pda;
SET timestamp=1675927412;
SELECT history.id AS history_id, history.msg AS history_msg, history.detail AS history_detail, history.created_by AS history_created_by, history.created_on AS history_created_on, history.domain_id AS history_domain_id
FROM history INNER JOIN domain ON history.domain_id = domain.id LEFT OUTER JOIN domain_user ON domain.id = domain_user.domain_id LEFT OUTER JOIN account ON domain.account_id = account.id LEFT OUTER JOIN account_user ON account.id = account_user.account_id
WHERE domain_user.user_id = 2 OR account_user.user_id = 2 ORDER BY history.created_on DESC;

mysql> describe SELECT history.id AS history_id, history.msg AS history_msg, history.detail AS history_detail, history.created_by AS history_created_by, history.created_on AS history_created_on, history.domain_id AS history_domain_id FROM
history INNER JOIN domain ON history.domain_id = domain.id LEFT OUTER JOIN domain_user ON domain.id = domain_user.domain_id LEFT OUTER JOIN account ON domain.account_id = account.id LEFT OUTER JOIN account_user ON account.id = account_user.account_id WHERE domain_user.user_id = 2 OR account_user.user_id = 2 ORDER BY history.created_on DESC;
+----+-------------+--------------+------------+--------+---------------+---------+---------+-----------------------+--------+----------+----------------------------------------------+
| id | select_type | table        | partitions | type   | possible_keys | key     | key_len | ref                   | rows   | filtered | Extra                                        |
+----+-------------+--------------+------------+--------+---------------+---------+---------+-----------------------+--------+----------+----------------------------------------------+
|  1 | SIMPLE      | history      | NULL       | ALL    | fk_domain_id  | NULL    | NULL    | NULL                  | 415710 |   100.00 | Using where; Using temporary; Using filesort |
|  1 | SIMPLE      | domain       | NULL       | eq_ref | PRIMARY       | PRIMARY | 4       | pda.history.domain_id |      1 |   100.00 | NULL                                         |
|  1 | SIMPLE      | domain_user  | NULL       | ALL    | domain_id     | NULL    | NULL    | NULL                  |      1 |   100.00 | Using where; Using join buffer (hash join)   |
|  1 | SIMPLE      | account      | NULL       | eq_ref | PRIMARY       | PRIMARY | 4       | pda.domain.account_id |      1 |   100.00 | Using index                                  |
|  1 | SIMPLE      | account_user | NULL       | ALL    | account_id    | NULL    | NULL    | NULL                  |      2 |   100.00 | Using where; Using join buffer (hash join)   |
+----+-------------+--------------+------------+--------+---------------+---------+---------+-----------------------+--------+----------+----------------------------------------------+
5 rows in set, 1 warning (0.00 sec)

# with force index:
mysql> describe SELECT history.id AS history_id, history.msg AS history_msg, history.detail AS history_detail, history.created_by AS history_created_by, history.created_on AS history_created_on, history.domain_id AS history_domain_id FROM history FORCE INDEX (ix_history_created_on) INNER JOIN domain ON history.domain_id = domain.id LEFT OUTER JOIN domain_user ON domain.id = domain_user.domain_id LEFT OUTER JOIN account ON domain.account_id = account.id LEFT OUTER JOIN account_user ON account.id = account_user.account_id WHERE domain_user.user_id = 2 OR account_user.user_id = 2 ORDER BY history.created_on DESC  LIMIT 4;
+----+-------------+--------------+------------+--------+---------------+-----------------------+---------+-----------------------+------+----------+----------------------------------+
| id | select_type | table        | partitions | type   | possible_keys | key                   | key_len | ref                   | rows | filtered | Extra                            |
+----+-------------+--------------+------------+--------+---------------+-----------------------+---------+-----------------------+------+----------+----------------------------------+
|  1 | SIMPLE      | history      | NULL       | index  | NULL          | ix_history_created_on | 6       | NULL                  |    2 |   100.00 | Using where; Backward index scan |
|  1 | SIMPLE      | domain       | NULL       | eq_ref | PRIMARY       | PRIMARY               | 4       | pda.history.domain_id |    1 |   100.00 | NULL                             |
|  1 | SIMPLE      | domain_user  | NULL       | ALL    | domain_id     | NULL                  | NULL    | NULL                  |    1 |   100.00 | Using where                      |
|  1 | SIMPLE      | account      | NULL       | eq_ref | PRIMARY       | PRIMARY               | 4       | pda.domain.account_id |    1 |   100.00 | Using index                      |
|  1 | SIMPLE      | account_user | NULL       | ALL    | account_id    | NULL                  | NULL    | NULL                  |    2 |   100.00 | Using where                      |
+----+-------------+--------------+------------+--------+---------------+-----------------------+---------+-----------------------+------+----------+----------------------------------+
5 rows in set, 1 warning (0.00 sec)
```

GUI improvement to extend dashboards actions column to 25% if user is allowed to view history.