### PR TITLE
Preserve domain records history after domain deletion

### DIFF
--- a/powerdnsadmin/models/domain.py
+++ b/powerdnsadmin/models/domain.py
@@ -548,11 +548,12 @@ class Domain(db.Model):
         domain.apikeys[:] = []
 
         # Remove history for domain
-        domain_history = History.query.filter(
-            History.domain_id == domain.id
-        )
-        if domain_history:
-           domain_history.delete()
+        if not Setting().get('preserve_history'):
+            domain_history = History.query.filter(
+                History.domain_id == domain.id
+            )
+            if domain_history:
+                domain_history.delete()
 
         # then remove domain
         Domain.query.filter(Domain.name == domain_name).delete()

--- a/powerdnsadmin/models/setting.py
+++ b/powerdnsadmin/models/setting.py
@@ -31,6 +31,7 @@ class Setting(db.Model):
 	    'delete_sso_accounts': False,
         'bg_domain_updates': False,
         'enable_api_rr_history': True,
+        'preserve_history': False,
         'site_name': 'PowerDNS-Admin',
         'site_url': 'http://localhost:9191',
         'session_timeout': 10,

--- a/powerdnsadmin/routes/admin.py
+++ b/powerdnsadmin/routes/admin.py
@@ -927,6 +927,13 @@ def history():
 					'msg': 'You do not have permission to remove history.'
 				}), 401)
 
+		if Setting().get('preserve_history'):
+			return make_response(
+				jsonify({
+					'status': 'error',
+					'msg': 'History removal is not allowed (toggle preserve_history in settings).'
+				}), 401)
+
 		h = History()
 		result = h.remove_all()
 		if result:
@@ -1282,6 +1289,7 @@ def setting_basic():
         'otp_field_enabled',
         'otp_force',
         'pdns_api_timeout',
+        'preserve_history',
         'pretty_ipv6_ptr',
         'record_helper',
         'record_quick_edit',


### PR DESCRIPTION
Introducing a new parameter to keep domain history intact in database. Current way is to remove history records by deleted domain_id, which is some environments isn't desired behaviour.
The default value of preserve_history is False and isn't a breaking change.