### PR TITLE
Domain records list performance improvement - removing Setting.get query from loop

### DIFF
--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -89,14 +89,14 @@ def domain(domain_name):
     #   - Find a way to make it consistent, or
     #   - Only allow one comment for that case
     if StrictVersion(Setting().get('pdns_version')) >= StrictVersion('4.0.0'):
+        pretty_v6 = Setting().get('pretty_ipv6_ptr')
         for r in rrsets:
             if r['type'] in records_allow_to_edit:
                 r_name = r['name'].rstrip('.')
 
                 # If it is reverse zone and pretty_ipv6_ptr setting
                 # is enabled, we reformat the name for ipv6 records.
-                if Setting().get('pretty_ipv6_ptr') and r[
-                        'type'] == 'PTR' and 'ip6.arpa' in r_name and '*' not in r_name:
+                if pretty_v6 and r['type'] == 'PTR' and 'ip6.arpa' in r_name and '*' not in r_name:
                     r_name = dns.reversename.to_address(
                         dns.name.from_text(r_name))
 


### PR DESCRIPTION
I moved pretty_ipv6_ptr setting retrieval out of record list loop. It's massive waste of resources when having large zones leading to unacceptable response time in UI.
example.com zone with 4000 records
Request URL: /domain/example.com

4000 queries hit SQL server: "SELECT setting.id AS setting_id, setting.name AS setting_name, setting.value AS setting_value FROM setting WHERE setting.name = 'pretty_ipv6_ptr'  LIMIT 1"

Browser "network" inspection:
19.49s (16.77s waiting for server response)
Same request and inspection report after this commit:
4.83s (2.54s waiting for server response).

Also related to issue #1009 (not resolving backend timeout, but still).