### PR TITLE
fix: configurable CAPTCHA_ENABLE env when docker use

### DIFF
--- a/configs/docker_config.py
+++ b/configs/docker_config.py
@@ -61,6 +61,7 @@ legal_envvars = (
     'FILESYSTEM_SESSIONS_ENABLED',
     'SESSION_COOKIE_SECURE',
     'CSRF_COOKIE_SECURE',
+    'CAPTCHA_ENABLE',
 )
 
 legal_envvars_int = ('PORT', 'MAIL_PORT', 'SAML_METADATA_CACHE_LIFETIME')
@@ -84,6 +85,7 @@ legal_envvars_bool = (
     'FILESYSTEM_SESSIONS_ENABLED',
     'SESSION_COOKIE_SECURE',
     'CSRF_COOKIE_SECURE',
+    'CAPTCHA_ENABLE',
 )
 
 # import everything from environment variables


### PR DESCRIPTION
Recently there was a PR merge where CAPTCHA_ENABLE environment variable was enabled by default, but it is easier to use if the user can disable it, so I made it changeable via environment variable.