### PR TITLE
Standard user domain records list performance loop improvement

### DIFF
--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -133,7 +133,8 @@ def domain(domain_name):
                            editable_records=editable_records,
                            quick_edit=quick_edit,
                            ttl_options=ttl_options,
-                           current_user=current_user)
+                           current_user=current_user,
+                           allow_user_view_history=Setting().get('allow_user_view_history'))
 
 
 @domain_bp.route('/remove', methods=['GET', 'POST'])

--- a/powerdnsadmin/templates/domain.html
+++ b/powerdnsadmin/templates/domain.html
@@ -36,7 +36,7 @@
                                         &nbsp;Zone Settings
                                     </button>
                                 {% endif %}
-                                {% if current_user.role.name in ['Administrator', 'Operator'] or SETTING.get('allow_user_view_history') %}
+                                {% if current_user.role.name in ['Administrator', 'Operator'] or allow_user_view_history %}
                                     <button type="button" title="Zone Changelog"
                                             class="btn btn-primary ml-2 mt-2 mb-2 button_changelog" id="{{ domain.name }}">
                                         <i class="fa-solid fa-history" aria-hidden="true"></i>
@@ -79,7 +79,7 @@
                                         <th>Comment</th>
                                         <th>Edit</th>
                                         <th>Delete</th>
-                                        {% if current_user.role.name in ['Administrator', 'Operator'] or SETTING.get('allow_user_view_history') %}
+                                        {% if current_user.role.name in ['Administrator', 'Operator'] or allow_user_view_history %}
                                             <th>Changelog</th>
                                         {% endif %}
                                     {% else %}
@@ -115,7 +115,7 @@
                                                     </button>
                                                 {% endif %}
                                             </td>
-                                            {% if current_user.role.name in ['Administrator', 'Operator'] or SETTING.get('allow_user_view_history') %}
+                                            {% if current_user.role.name in ['Administrator', 'Operator'] or allow_user_view_history %}
                                                 <td>
                                                     <button type="button"
                                                             onclick="show_record_changelog('{{ record.name }}','{{ record.type }}',event)"
@@ -194,7 +194,7 @@
                     // regardless of whatever sorting is done. See orderFixed
                     visible: false,
                     {% if domain.type != 'Slave' %}
-                        {% if current_user.role.name in ['Administrator', 'Operator'] or SETTING.get('allow_user_view_history') %}
+                        {% if current_user.role.name in ['Administrator', 'Operator'] or allow_user_view_history %}
                             targets: [9]
                         {% else %}
                             targets: [8]
@@ -205,7 +205,7 @@
                 }
             ],
             {% if domain.type != 'Slave' %}
-                {% if current_user.role.name in ['Administrator', 'Operator'] or SETTING.get('allow_user_view_history') %}
+                {% if current_user.role.name in ['Administrator', 'Operator'] or allow_user_view_history %}
                     "orderFixed": [[9, 'asc']]
                 {% else %}
                     "orderFixed": [[8, 'asc']]
@@ -314,7 +314,7 @@
 
             // add new row
             var default_type = records_allow_edit[0]
-            {% if current_user.role.name in ['Administrator', 'Operator'] or SETTING.get('allow_user_view_history') %}
+            {% if current_user.role.name in ['Administrator', 'Operator'] or allow_user_view_history %}
                 var nRow = jQuery('#tbl_records').dataTable().fnAddData(['', default_type, 'Active', window.ttl_options[0][0], '', '', '', '', '', '0']);
             {% else %}
                 var nRow = jQuery('#tbl_records').dataTable().fnAddData(['', default_type, 'Active', window.ttl_options[0][0], '', '', '', '', '0']);


### PR DESCRIPTION
There's a performance degrading setting verification in domain.html template records loop.
If the user is standard user and there's are a lot of records in the zone, the SQL backend gets a query 
`SELECT setting.id AS setting_id, setting.name AS setting_name, setting.value AS setting_value FROM setting WHERE setting.name = 'allow_user_view_history'  LIMIT 1` for every record.
While requesting simple in-addr.arpa zone with 256 records, SQL gets 268 indentical queries about allow_user_view_history. This issue has been in the template loop for ages. 

I added a simple variable to template rendering function and replaced Setting().get('allow_user_view_history') with a simple template variable check. SQL backend will be a lot happier.