### PR TITLE
Fixed scrolling on long content

### DIFF
--- a/powerdnsadmin/templates/domain.html
+++ b/powerdnsadmin/templates/domain.html
@@ -148,7 +148,7 @@
         table#tbl_records thead th:nth-child(4) { width: 100px; }
         table#tbl_records tbody td { text-align: center; }
         table#tbl_records tbody td:nth-child(0n+5),
-        table#tbl_records tbody td:nth-child(0n+6) { text-align: left; }
+        table#tbl_records tbody td:nth-child(0n+6) { text-align: left; word-break: break-all; }
     </style>
 {% endblock %}
 


### PR DESCRIPTION
If a record has a long content value, the table is scrollable and the action buttons are not visible until you scroll to the end.
This change breaks the content value (and the comment) to make the table fit on the screen.

Before:
![SCR-20230302-m2q](https://user-images.githubusercontent.com/6099976/222467691-79a013af-5f5d-4f5a-aa7f-30230ecd5cd4.png)

After:
![SCR-20230302-m2q-2](https://user-images.githubusercontent.com/6099976/222467701-e4dfae5a-4bc7-4893-b5e6-9d7e60adc46d.png)
