### PR TITLE
Sort records label-wise right to left

### DIFF
--- a/powerdnsadmin/templates/domain.html
+++ b/powerdnsadmin/templates/domain.html
@@ -202,6 +202,17 @@
                     {% else %}
                         targets: [5]
                     {% endif %}
+                },
+                {
+                    targets: [0],
+                    className: "text-right",
+                    data: {
+                        '_': "0",
+                        'sort': function (row, _type, _set, _meta) {
+                            const data = row[0] || '';
+                            return data.split('.').reverse().join('.');
+                        },
+                    },
                 }
             ],
             {% if domain.type != 'Slave' %}


### PR DESCRIPTION
Account for the hierarchical nature of DNS by sorting records in the zone view by their name, label-wise from right to left. Also justify the record names to the right, so they visually line up on label borders.

This uses the [object variant of the `data` column option](https://datatables.net/reference/option/columns.data#object).