### PR TITLE
Clean up dashboard zone tabs

### DIFF
--- a/powerdnsadmin/lib/utils.py
+++ b/powerdnsadmin/lib/utils.py
@@ -227,15 +227,6 @@ def ensure_list(l):
     yield from l
 
 
-class customBoxes:
-    boxes = {
-        "reverse": (" ", " "),
-        "ip6arpa": ("ip6", "%.ip6.arpa"),
-        "inaddrarpa": ("in-addr", "%.in-addr.arpa")
-    }
-    order = ["reverse", "ip6arpa", "inaddrarpa"]
-
-
 def pretty_domain_name(domain_name):
     # Add a debugging statement to print out the domain name
     print("Received domain name:", domain_name)

--- a/powerdnsadmin/routes/dashboard.py
+++ b/powerdnsadmin/routes/dashboard.py
@@ -1,10 +1,10 @@
 import datetime
-from flask import Blueprint, render_template, url_for, current_app, request, jsonify, redirect, g, session
+from collections import namedtuple
+from flask import Blueprint, render_template, url_for, current_app, request, jsonify, redirect, g, session, abort
 from flask_login import login_required, current_user, login_manager
 from sqlalchemy import not_
 
 from ..decorators import operator_role_required
-from ..lib.utils import customBoxes
 from ..models.user import User, Anonymous
 from ..models.account import Account
 from ..models.account_user import AccountUser
@@ -19,6 +19,31 @@ dashboard_bp = Blueprint('dashboard',
                          __name__,
                          template_folder='templates',
                          url_prefix='/dashboard')
+
+
+class ZoneTabs:
+    """Config data for the zone tabs on the dashboard."""
+
+    TabInfo = namedtuple('TabInfo', ['display_name', 'filter_pattern'])
+    """Info about a single tab.
+
+    `display_name` is the name on the tab.
+    `filter_pattern` is a SQL LIKE pattern , which is case-insensitively matched against the zone
+    name (without the final root-dot).
+
+    If a filter is present, the tab will show zones that match the filter.
+    If no filter is present, the tab will show zones that are not matched by any other tab filter.
+    """
+
+    tabs = {
+        'forward':      TabInfo("", None),
+        'reverse_ipv4': TabInfo("in-addr.arpa", '%.in-addr.arpa'),
+        'reverse_ipv6': TabInfo("ip6.arpa", '%.ip6.arpa'),
+    }
+    """Dict of unique tab id to a TabInfo."""
+
+    order = ['forward', 'reverse_ipv4', 'reverse_ipv6']
+    """List of tab ids in the order they will appear."""
 
 
 @dashboard_bp.before_request
@@ -41,9 +66,12 @@ def before_request():
     session.modified = True
 
 
-@dashboard_bp.route('/domains-custom/<path:boxId>', methods=['GET'])
+@dashboard_bp.route('/domains-custom/<path:tab_id>', methods=['GET'])
 @login_required
-def domains_custom(boxId):
+def domains_custom(tab_id):
+    if tab_id not in ZoneTabs.tabs:
+        abort(404)
+
     if current_user.role.name in ['Administrator', 'Operator']:
         domains = Domain.query
     else:
@@ -83,14 +111,15 @@ def domains_custom(boxId):
     if order_by:
         domains = domains.order_by(*order_by)
 
-    if boxId == "reverse":
-        for boxId in customBoxes.order:
-            if boxId == "reverse": continue
-            domains = domains.filter(
-                not_(Domain.name.ilike(customBoxes.boxes[boxId][1])))
+    if ZoneTabs.tabs[tab_id].filter_pattern:
+        # If the tab has a filter, use only that
+        domains = domains.filter(Domain.name.ilike(ZoneTabs.tabs[tab_id].filter_pattern))
     else:
-        domains = domains.filter(Domain.name.ilike(
-            customBoxes.boxes[boxId][1]))
+        # If the tab has no filter, use all the other filters in negated form
+        for tab_info in ZoneTabs.tabs.values():
+            if not tab_info.filter_pattern:
+                continue
+            domains = domains.filter(not_(Domain.name.ilike(tab_info.filter_pattern)))
 
     total_count = domains.count()
 
@@ -202,7 +231,7 @@ def dashboard():
 
     # Add custom boxes to render_template
     return render_template('dashboard.html',
-                           custom_boxes=customBoxes,
+                           zone_tabs=ZoneTabs,
                            domain_count=domain_count,
                            user_num=user_num,
                            history_number=history_number,

--- a/powerdnsadmin/templates/dashboard.html
+++ b/powerdnsadmin/templates/dashboard.html
@@ -176,17 +176,11 @@
                                 <div class="nav-tabs-custom">
                                     <ul class="nav nav-tabs card-header-tabs" id="custom-content-below-tab"
                                         role="tablist">
-                                        <li class="nav-item">
-                                            <a class="nav-link active" href="#tab_{{ custom_boxes.order[0] }}"
-                                               data-toggle="pill" role="tab">
-                                                Zones <b>{{ custom_boxes.boxes[custom_boxes.order[0]][0] }}</b>
-                                            </a>
-                                        </li>
-                                        {% for boxId in custom_boxes.order[1:] %}
+                                        {% for tab_id in zone_tabs.order %}
                                             <li class="nav-item">
-                                                <a class="nav-link" href="#tab_{{ boxId }}" data-toggle="pill"
-                                                   role="tab">
-                                                    Zones <b>{{ custom_boxes.boxes[boxId][0] }}</b>
+                                                <a class="nav-link {% if loop.first %}active{% endif %}"
+                                                   href="#tab_{{ tab_id }}" data-toggle="pill" role="tab">
+                                                    Zones <b>{{ zone_tabs.tabs[tab_id].display_name }}</b>
                                                 </a>
                                             </li>
                                         {% endfor %}
@@ -197,10 +191,11 @@
                         <!-- /.card-header -->
                         <div class="card-body p-0">
                             <div class="tab-content">
-                                {% for boxId in custom_boxes.order %}
-                                    <div class="tab-pane show" id='tab_{{ boxId }}'>
+                                {% for tab_id in zone_tabs.order %}
+                                    <div id='tab_{{ tab_id }}'
+                                         class="tab-pane show {% if loop.first %}active{% endif %}">
                                         <div class="card-body table-responsive records p-0 pt-2">
-                                            <table id='tbl_domain_list_{{ boxId }}'
+                                            <table id='tbl_domain_list_{{ tab_id }}'
                                                    class="table table-striped table-hover table-sm records">
                                                 <thead>
                                                 <tr>
@@ -274,9 +269,8 @@
             });
         }
 
-        $('#tab_{{custom_boxes.order[0]}}').addClass("active");
-        {% for boxId in custom_boxes.order %}
-            setUpDomainList("#tbl_domain_list_{{boxId}}", "{{url_for('dashboard.domains_custom',boxId=boxId)}}");
+        {% for tab_id in zone_tabs.order %}
+            setUpDomainList("#tbl_domain_list_{{tab_id}}", "{{url_for('dashboard.domains_custom',tab_id=tab_id)}}");
         {% endfor %}
         //SYBPATCH END//
 


### PR DESCRIPTION
I was playing around with zone tabs (or "custom boxes" as they were called) on the dashboard, and after writing docs it felt in need of a little cleanup. They are still hard-coded, but easily customised using a patch e.g. in a Dockerfile.

Fun fact: You can "hide" zones by adding a matching TabInfo to the `tabs` dict, but not add it to the `order` list.

* Rename `customBoxes` to be more descriptive and follow CamelCase name convention for classes
* Moved the class to the dashboard route where it is only used
* Change the tab info from a tuple to a named tuple
* Change all access to the tab info tuple from index to (new) property name
* Rename/Relabel the tabs
* Add docstrings
* Simplify the domain filter logic
* Simplify/Unify the tab html template