### PR TITLE
Diff-ify changelog view for zone changes

### DIFF
--- a/powerdnsadmin/static/custom/css/custom.css
+++ b/powerdnsadmin/static/custom/css/custom.css
@@ -57,3 +57,26 @@ table.records thead th:last-of-type { width: 50px; }
 div.records > div.dataTables_wrapper > div.row:first-of-type { margin: 0 0.5em 0 0.5em; }
 div.records > div.dataTables_wrapper > div.row:last-of-type { margin: 0.4em 0.5em 0.4em 0.5em; }
 div.records > div.dataTables_wrapper table.dataTable { margin: 0 !important; }
+
+.diff {
+    font-family: monospace;
+    padding: 0 0.2em;
+}
+.diff::before {
+    content: "\00a0";
+    padding-right: 0.1em;
+}
+
+.diff-deletion {
+    background-color: lightcoral;
+}
+.diff-deletion::before {
+    content: "-";
+}
+
+.diff-addition {
+    background-color: lightgreen;
+}
+.diff-addition::before {
+    content: "+";
+}

--- a/powerdnsadmin/templates/admin_history.html
+++ b/powerdnsadmin/templates/admin_history.html
@@ -537,7 +537,7 @@
     </div>
     <!-- History Details Box -->
     <div class="modal fade" id="modal_history_info">
-        <div class="modal-dialog">
+        <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
                     <h4 class="modal-title">History Details</h4>

--- a/powerdnsadmin/templates/applied_change_macro.html
+++ b/powerdnsadmin/templates/applied_change_macro.html
@@ -4,129 +4,110 @@
 <table id="tbl_records" class="table table-bordered">
     <thead>
         <tr>
-            <th colspan="3">
-                {% if hist_rec_entry.change_type == "+" %}
-                <span
-                    style="background-color:  lightgreen">{{hist_rec_entry.add_rrset['name']}}
-                    {{hist_rec_entry.add_rrset['type']}}</span>
-                {% elif hist_rec_entry.change_type == "-" %}
-                <s
-                    style="text-decoration-color: rgba(194, 10,10, 0.6); text-decoration-thickness: 2px;">
-                    {{hist_rec_entry.del_rrset['name']}}
-                    {{hist_rec_entry.del_rrset['type']}}
-                </s>
+            <th scope="col" colspan="3">
+                {% if hist_rec_entry.change_type == '-' %}
+                    <span class="diff diff-deletion">{{
+                        hist_rec_entry.del_rrset['name'] }} {{ hist_rec_entry.del_rrset['type']
+                    }}</span>
+                {% elif hist_rec_entry.change_type == '+' %}
+                    <span class="diff diff-addition">{{
+                        hist_rec_entry.add_rrset['name'] }} {{ hist_rec_entry.add_rrset['type']
+                    }}</span>
                 {% else %}
-                {{hist_rec_entry.add_rrset['name']}}
-                {{hist_rec_entry.add_rrset['type']}}
+                    <span class="diff diff-unchanged">{{
+                        hist_rec_entry.add_rrset['name'] }} {{ hist_rec_entry.add_rrset['type']
+                    }}</span>
                 {% endif %}
 
-                , TTL:
-                {% if "ttl" in hist_rec_entry.changed_fields %}
-                <s
-                    style="text-decoration-color: rgba(194, 10,10, 0.6); text-decoration-thickness: 2px;">
-                    {{hist_rec_entry.del_rrset['ttl']}}</s>
-                <span
-                    style="background-color:  lightgreen">{{hist_rec_entry.add_rrset['ttl']}}</span>
+                , TTL
+                {% if not 'ttl' in hist_rec_entry.changed_fields %}
+                    <span class="diff diff-unchanged">{{
+                        hist_rec_entry.add_rrset['ttl']
+                    }}</span>
                 {% else %}
-                {{hist_rec_entry.add_rrset['ttl']}}
+                    {% if hist_rec_entry.change_type in ['-', '*'] %}
+                        <span class="diff diff-deletion">{{
+                            hist_rec_entry.del_rrset['ttl']
+                        }}</span>
+                    {% endif %}
+                    {% if hist_rec_entry.change_type in ['+', '*'] %}
+                        <span class="diff diff-addition">{{
+                            hist_rec_entry.add_rrset['ttl']
+                        }}</span>
+                    {% endif %}
                 {% endif %}
 
             </th>
         </tr>
+
         <tr>
-
-            <th style="width: 150px;">Status</th>
-            <th style="width: 400px;">Data</th>
-            <th style="width: 400px;">Comment</th>
-
+            <th scope="col" style="width: 150px;">Status</th>
+            <th scope="col" style="width: 400px;">Data</th>
+            <th scope="col" style="width: 400px;">Comment</th>
         </tr>
     </thead>
     <tbody>
+        {% for changes in hist_rec_entry.changeSet %}
         <tr>
-            <td>
-                <table>
-                    <tbody>
-                        {% for changes in hist_rec_entry.changeSet %}
-                        <tr>
-                            {% if changes[2] == "unchanged" %}
-                            <td>{{ "Activated" if changes[0]['disabled'] ==
-                                False else
-                                "Disabled"}} </td>
-                            {% elif changes[2] == "addition" %}
-                            <td>
-                                <span style="background-color:  lightgreen">
-                                    {{ "Activated" if changes[1]['disabled'] ==
-                                    False else
-                                    "Disabled"}}
-                                </span>
-                            </td>
-                            {% elif changes[2] == "status" %}
-                            <td>
-                                <s
-                                    style="text-decoration-color: rgba(194, 10,10, 0.6); text-decoration-thickness: 2px;">
-                                    {{ "Activated" if changes[0]['disabled'] ==
-                                    False else
-                                    "Disabled"}}</s>
-                                <span style="background-color:  lightgreen">{{
-                                    "Activated" if changes[1]['disabled'] ==
-                                    False else
-                                    "Disabled"}}</span>
-                            </td>
-                            {% elif changes[2] == "deletion" %}
-                            <td>
-                                <s
-                                    style="text-decoration-color: rgba(194, 10,10, 0.6); text-decoration-thickness: 2px;">
-                                    {{ "Activated" if changes[0]['disabled'] ==
-                                    False else
-                                    "Disabled"}}</s>
-                            </td>
-                            {% endif %}
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </td>
-            <td>
-                <table>
-                    <tbody>
-                        {% for changes in hist_rec_entry.changeSet %}
-                        <tr>
-                            {% if changes[2] == "unchanged" %}
-                            <td style="word-break: break-all">
-                                {{changes[0]['content']}}
-                            </td>
-                            {% elif changes[2] == "addition" %}
-                            <td style="word-break: break-all">
-                                <span style="background-color:  lightgreen">
-                                    {{changes[1]['content']}}
-                                </span>
-                            </td>
-                            {% elif changes[2] == "deletion" %}
-                            <td style="word-break: break-all">
-                                <s
-                                    style="text-decoration-color: rgba(194, 10, 10, 0.6); text-decoration-thickness: 2px;">
-                                    {{changes[0]['content']}}
-                                </s>
-                            </td>
-                            {% elif changes[2] == "status" %}
-                            <td style="word-break: break-all">
-                                {{changes[0]['content']}}
-                            </td>
-                            {% endif %}
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-
-                </table>
+            <td style="word-break: break-all">
+                {% if changes[2] == "unchanged" or
+                    (changes[2] == "edit" and changes[0]['disabled'] == changes[1]['disabled']) %}
+                    <div class="diff diff-unchanged">{{
+                        "Disabled" if changes[1]['disabled'] else "Activated"
+                    }}</div>
+                {% else %}
+                    {% if changes[2] in ["deletion", "edit"] %}
+                        <div class="diff diff-deletion">{{
+                            "Disabled" if changes[0]['disabled'] else "Activated"
+                        }}</div>
+                    {% endif %}
+                    {% if changes[2] in ["addition", "edit"] %}
+                        <div class="diff diff-addition">{{
+                            "Disabled" if changes[1]['disabled'] else "Activated"
+                        }}</div>
+                    {% endif %}
+                {% endif %}
             </td>
             <td style="word-break: break-all">
-                {% for comments in hist_rec_entry.add_rrset['comments'] %}
-                {{comments['content'] }}
-                <br/>
-                {% endfor %}
+                {% if changes[2] == "unchanged" or
+                        (changes[2] == "edit" and changes[0]['content'] == changes[1]['content']) %}
+                    <div class="diff diff-unchanged">{{
+                        changes[1]['content']
+                    }}</div>
+                {% else %}
+                    {% if changes[2] in ["deletion", "edit"] %}
+                        <div class="diff diff-deletion">{{
+                            changes[0]['content']
+                        }}</div>
+                    {% endif %}
+                    {% if changes[2] in ["addition", "edit"] %}
+                        <div class="diff diff-addition">{{
+                            changes[1]['content']
+                        }}</div>
+                    {% endif %}
+                {% endif %}
+            </td>
+            <td style="word-break: break-all">
+                {% if changes[2] == "unchanged" or
+                        (changes[2] == "edit" and changes[0]['comment'] == changes[1]['comment']) %}
+                    <div class="diff diff-unchanged">{{
+                        changes[1]['comment']
+                    }}</div>
+                {% else %}
+                    {% if changes[2] in ["deletion", "edit"] and changes[0]['comment'] %}
+                        <div class="diff diff-deletion">{{
+                            changes[0]['comment']
+                        }}</div>
+                    {% endif %}
+                    {% if changes[2] in ["addition", "edit"] and changes[1]['comment'] %}
+                        <div class="diff diff-addition">{{
+                            changes[1]['comment']
+                        }}</div>
+                    {% endif %}
+                {% endif %}
             </td>
         </tr>
-
+        {% endfor %}
     </tbody>
 </table>
 {% endfor %}


### PR DESCRIPTION
The idea is to have a more fine-grained changelog where you can easily see on a per-field level if it changed, and what the old and/or new value is. Visual-vise I leaned on the common diff formats by using the `+` prefix with green colouring, and `-` with red colouring.