### PR TITLE
Small fix for subfolder proxying, Documentation, small fix for build process hangs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ COPY . /build
 # Prepare assets
 RUN yarn install --pure-lockfile --production && \
     yarn cache clean && \
-    sed -i -r -e "s|'cssmin',\s?'cssrewrite'|'cssmin'|g" /build/powerdnsadmin/assets.py && \
+    sed -i -r -e "s|'cssmin',\s?'cssrewrite'|'rcssmin'|g" /build/powerdnsadmin/assets.py && \
     flask assets build
 
 RUN mv /build/powerdnsadmin/static /tmp/static && \

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -34,7 +34,7 @@
 - [Systemd + Gunicorn + Apache](web-server/Running-PowerDNS-Admin-with-Systemd,-Gunicorn-and-Apache.md)
 - [uWSGI](web-server/uWSGI-example.md)
 - [WSGI-Apache](web-server/WSGI-Apache-example.md)
-- [Docker-ApacheReverseProxy](webserver/Running-Docker-Apache-Reverseproxy.md)
+- [Docker-ApacheReverseProxy](web-server/Running-Docker-Apache-Reverseproxy.md)
 
 ## Using PowerDNS-Admin
 

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -34,6 +34,7 @@
 - [Systemd + Gunicorn + Apache](web-server/Running-PowerDNS-Admin-with-Systemd,-Gunicorn-and-Apache.md)
 - [uWSGI](web-server/uWSGI-example.md)
 - [WSGI-Apache](web-server/WSGI-Apache-example.md)
+- [Docker-ApacheReverseProxy](webserver/Running-Docker-Apache-Reverseproxy.md)
 
 ## Using PowerDNS-Admin
 
@@ -44,3 +45,7 @@
 ## Feature usage
 
 - [DynDNS2](features/DynDNS2.md)
+
+## Debugging
+
+- [Debugging the build process](debug/build-process.md)

--- a/docs/wiki/debug/build-process.md
+++ b/docs/wiki/debug/build-process.md
@@ -1,0 +1,61 @@
+This discribes how to debug the buildprocess 
+
+
+docker-compose.yml
+
+```
+version: "3"
+services:
+  app:
+    image: powerdns/custom
+    container_name: powerdns
+    restart: always
+    build:
+        context: git
+        dockerfile: docker/Dockerfile
+    network_mode: "host"
+    logging:
+      driver: json-file
+      options:
+        max-size: 50m
+    environment:
+      - BIND_ADDRESS=127.0.0.1:8082
+      - SECRET_KEY='VerySecret'
+      - SQLALCHEMY_DATABASE_URI=mysql://pdnsadminuser:password@127.0.0.1/powerdnsadmin
+      - GUNICORN_TIMEOUT=60
+      - GUNICORN_WORKERS=2
+      - GUNICORN_LOGLEVEL=DEBUG
+      - OFFLINE_MODE=False
+      - CSRF_COOKIE_SECURE=False
+```
+
+Create a git folder in the location of the `docker-compose.yml` and clone the repo into it
+
+```
+mkdir git
+cd git 
+git clone https://github.com/PowerDNS-Admin/PowerDNS-Admin.git .
+```
+
+In case you are behind an SSL Filter like me, you can add the following to each stage of the `git/docker/Dockerfile`
+
+This installs the command `update-ca-certificates` from the alpine repo and adds an ssl cert to the trust chain, make sure you are getting the right version in case the base image version changes
+
+```
+RUN mkdir /tmp-pkg && cd /tmp-pkg && wget http://dl-cdn.alpinelinux.org/alpine/v3.17/main/x86_64/ca-certificates-20220614-r4.apk && apk add --allow-untrusted --no-network --no-cache /tmp-pkg/ca-certificates-20220614-r4.apk || true
+RUN rm -rf /tmp/pkg
+COPY MyCustomCerts.crt /usr/local/share/ca-certificates/MyCustomCerts.crt
+RUN update-ca-certificates
+COPY pip.conf /etc/pip.conf
+```
+
+`MyCustomCerts.crt` and `pip.conf` have to be placed inside the `git` folder.
+
+The content of `pip.conf` is:
+
+```
+[global]
+cert = /usr/local/share/ca-certificates/MyCustomCerts.crt
+```
+
+For easier debugging you can change the `CMD` of the `Dockerfile` to `CMD ["tail","-f", "/dev/null"]` though I expect you to be fluent in Docker in case you wish to debug

--- a/docs/wiki/web-server/Running-Docker-Apache-Reverseproxy.md
+++ b/docs/wiki/web-server/Running-Docker-Apache-Reverseproxy.md
@@ -1,0 +1,73 @@
+This describes how to run Apache2 on the host system with a reverse proxy directing to the docker container
+
+This is usually used to add ssl certificates and prepend a subdirectory
+
+The network_mode host settings is not neccessary but used for ldap availability in this case
+
+
+docker-compose.yml
+
+```
+version: "3"
+services:
+  app:
+    image: powerdnsadmin/pda-legacy:latest
+    container_name: powerdns
+    restart: always
+    network_mode: "host"
+    logging:
+      driver: json-file
+      options:
+        max-size: 50m
+    environment:
+      - BIND_ADDRESS=127.0.0.1:8082
+      - SECRET_KEY='NotVerySecret'
+      - SQLALCHEMY_DATABASE_URI=mysql://pdnsadminuser:password@127.0.0.1/powerdnsadmin
+      - GUNICORN_TIMEOUT=60
+      - GUNICORN_WORKERS=2
+      - GUNICORN_LOGLEVEL=DEBUG
+      - OFFLINE_MODE=False
+      - CSRF_COOKIE_SECURE=False
+      - SCRIPT_NAME=/powerdns
+```
+
+After running the Container create the static directory and populate
+
+```
+mkdir -p /var/www/powerdns
+docker cp powerdns:/app/powerdnsadmin/static /var/www/powerdns/
+chown -R root:www-data /var/www/powerdns
+```
+
+Adjust the static reference, static/assets/css has a hardcoded reference
+
+```
+sed -i 's/\/static/\/powerdns\/static/' /var/www/powerdns/static/assets/css/*
+```
+
+Apache Config:
+
+You can set the SCRIPT_NAME environment using Apache as well, once is sufficient though
+
+```
+    <Location /powerdns>
+        RequestHeader set X-Forwarded-Proto "https"
+        RequestHeader set X-Forwarded-Port "443"
+        RequestHeader set SCRIPT_NAME "/powerdns"
+        ProxyPreserveHost On
+    </Location>
+
+    ProxyPass /powerdns/static !
+    ProxyPass /powerdns http://127.0.0.1:8082/powerdns
+    ProxyPassReverse /powerdns http://127.0.0.1:8082/powerdns
+
+    Alias /powerdns/static "/var/www/powerdns/static"
+
+    <Directory "/var/www/powerdns/static">
+        Options None
+        #Options +Indexes
+        AllowOverride None
+        Order allow,deny
+        Allow from all
+    </Directory>
+```

--- a/powerdnsadmin/templates/admin_history.html
+++ b/powerdnsadmin/templates/admin_history.html
@@ -216,7 +216,7 @@
 
         $(document).ready(function () {
             $.ajax({
-                url: "/admin/history_table",
+                url: '{{ url_for("admin.history_table") }}',
                 type: "get",
                 success: function (response) {
                     console.log('Submission was successful.');
@@ -493,7 +493,7 @@
                 var form = $(this);
                 var tzoffset = (new Date()).getTimezoneOffset();
                 $.ajax({
-                    url: "/admin/history_table",
+                    url: '{{ url_for("admin.history_table") }}',
                     type: "get",
                     data: form.serialize() + "&tzoffset=" + tzoffset,
                     success: function (response) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ rjsmin==1.2.1
 webcolors==1.12
 werkzeug==2.1.2
 zipp==3.11.0
+rcssmin==1.1.1


### PR DESCRIPTION
I had the issue that the build from master was hanging up on "flask assets build"
I switched the the filter to rcssmin, cssmin is only available in 0.2.0 in pip which is stone age old.

rcssmin was added to the requirements, build works fine.

I documented how to set up an apache reverse proxy with subfolder using the SCRIPT_PATH environment variable.

There was a small error in powerdnsadmin/templates/admin_history.html using static urls instead of url_for