### PR TITLE
Update lxml version to support python3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ gunicorn==20.1.0
 itsdangerous==2.1.2
 jsonschema[format]>=2.5.1,<4.0.0 # until https://github.com/Yelp/bravado-core/pull/385
 lima==0.5
-lxml==4.6.5
+lxml==4.9.0
 mysqlclient==2.0.1
 passlib==1.7.4
 #pyOpenSSL==22.1.0
@@ -33,7 +33,7 @@ pyasn1==0.4.8
 pyotp==2.8.0
 pytest==7.2.1
 python-ldap==3.4.3
-python3-saml==1.14.0
+python3-saml==1.15.0
 pytimeparse==1.1.8
 pytz==2022.7.1
 qrcode==7.3.1


### PR DESCRIPTION
This PR updates lxml version to suport python3.11
python3-saml also has to be updated because of a dependancy.
