### PR TITLE
Feature: Add OAuth Setting for Server Metadata URL

### DIFF
--- a/powerdnsadmin/models/setting.py
+++ b/powerdnsadmin/models/setting.py
@@ -73,6 +73,7 @@ class Setting(db.Model):
         'github_oauth_authorize_url':
             'https://github.com/login/oauth/authorize',
         'github_oauth_jwks_url': '',
+        'github_oauth_metadata_url': '',
         'google_oauth_enabled': False,
         'google_oauth_client_id': '',
         'google_oauth_client_secret': '',
@@ -80,6 +81,7 @@ class Setting(db.Model):
         'google_oauth_scope': 'openid email profile',
         'google_authorize_url': 'https://accounts.google.com/o/oauth2/v2/auth',
         'google_oauth_jwks_url': '',
+        'google_oauth_metadata_url': '',
         'google_base_url': 'https://www.googleapis.com/oauth2/v3/',
         'azure_oauth_enabled': False,
         'azure_oauth_key': '',
@@ -91,6 +93,7 @@ class Setting(db.Model):
         'azure_oauth_authorize_url':
             'https://login.microsoftonline.com/[tenancy]/oauth2/v2.0/authorize',
         'azure_oauth_jwks_url': '',
+        'azure_oauth_metadata_url': '',
         'azure_sg_enabled': False,
         'azure_admin_group': '',
         'azure_operator_group': '',

--- a/powerdnsadmin/routes/admin.py
+++ b/powerdnsadmin/routes/admin.py
@@ -1636,6 +1636,8 @@ def setting_authentication():
                               request.form.get('google_oauth_client_id'))
                 Setting().set('google_oauth_client_secret',
                               request.form.get('google_oauth_client_secret'))
+                Setting().set('google_oauth_metadata_url',
+                              request.form.get('google_oauth_metadata_url'))
                 Setting().set('google_token_url',
                               request.form.get('google_token_url'))
                 Setting().set('google_oauth_scope',
@@ -1671,6 +1673,8 @@ def setting_authentication():
                               request.form.get('github_oauth_scope'))
                 Setting().set('github_oauth_api_url',
                               request.form.get('github_oauth_api_url'))
+                Setting().set('github_oauth_metadata_url',
+                              request.form.get('github_oauth_metadata_url'))
                 Setting().set('github_oauth_token_url',
                               request.form.get('github_oauth_token_url'))
                 Setting().set('github_oauth_authorize_url',
@@ -1702,6 +1706,8 @@ def setting_authentication():
                               request.form.get('azure_oauth_scope'))
                 Setting().set('azure_oauth_api_url',
                               request.form.get('azure_oauth_api_url'))
+                Setting().set('azure_oauth_metadata_url',
+                              request.form.get('azure_oauth_metadata_url'))
                 Setting().set('azure_oauth_token_url',
                               request.form.get('azure_oauth_token_url'))
                 Setting().set('azure_oauth_authorize_url',
@@ -1755,14 +1761,14 @@ def setting_authentication():
                               request.form.get('oidc_oauth_scope'))
                 Setting().set('oidc_oauth_api_url',
                               request.form.get('oidc_oauth_api_url'))
+                Setting().set('oidc_oauth_metadata_url',
+                              request.form.get('oidc_oauth_metadata_url'))
                 Setting().set('oidc_oauth_token_url',
                               request.form.get('oidc_oauth_token_url'))
                 Setting().set('oidc_oauth_authorize_url',
                               request.form.get('oidc_oauth_authorize_url'))
                 Setting().set('oidc_oauth_jwks_url',
                               request.form.get('oidc_oauth_jwks_url'))
-                Setting().set('oidc_oauth_metadata_url',
-                              request.form.get('oidc_oauth_metadata_url'))
                 Setting().set('oidc_oauth_logout_url',
                               request.form.get('oidc_oauth_logout_url'))
                 Setting().set('oidc_oauth_username',

--- a/powerdnsadmin/services/azure.py
+++ b/powerdnsadmin/services/azure.py
@@ -24,6 +24,7 @@ def azure_oauth():
         access_token_url=Setting().get('azure_oauth_token_url'),
         authorize_url=Setting().get('azure_oauth_authorize_url'),
         jwks_url=Setting().get('azure_oauth_jwks_url'),
+        server_metadata_url=Setting().get('azure_oauth_metadata_url'),
         client_kwargs={'scope': Setting().get('azure_oauth_scope')},
         fetch_token=fetch_azure_token,
     )

--- a/powerdnsadmin/services/github.py
+++ b/powerdnsadmin/services/github.py
@@ -25,6 +25,7 @@ def github_oauth():
         access_token_url=Setting().get('github_oauth_token_url'),
         authorize_url=Setting().get('github_oauth_authorize_url'),
         jwks_url=Setting().get('github_oauth_jwks_url'),
+        server_metadata_url=Setting().get('github_oauth_metadata_url'),
         client_kwargs={'scope': Setting().get('github_oauth_scope')},
         fetch_token=fetch_github_token,
         update_token=update_token)

--- a/powerdnsadmin/services/google.py
+++ b/powerdnsadmin/services/google.py
@@ -24,6 +24,7 @@ def google_oauth():
         access_token_url=Setting().get('google_token_url'),
         authorize_url=Setting().get('google_authorize_url'),
         jwks_url=Setting().get('google_oauth_jwks_url'),
+        server_metadata_url=Setting().get('google_oauth_metadata_url'),
         client_kwargs={'scope': Setting().get('google_oauth_scope')},
         fetch_token=fetch_google_token,
         update_token=update_token)

--- a/powerdnsadmin/templates/admin_setting_authentication.html
+++ b/powerdnsadmin/templates/admin_setting_authentication.html
@@ -630,9 +630,16 @@
                                                                            value="{{ SETTING.get('google_oauth_client_secret') }}">
                                                                     <span class="help-block with-errors"></span>
                                                                 </div>
-                                                            </fieldset>
-                                                            <fieldset>
-                                                                <legend>ADVANCE</legend>
+                                                                <div class="form-group">
+                                                                    <label for="google_oauth_metadata_url">Metadata URL</label>
+                                                                    <input type="text" class="form-control"
+                                                                           name="google_oauth_metadata_url"
+                                                                           id="google_oauth_metadata_url"
+                                                                           placeholder="e.g. https://{yourDomain}/.well-known/oauth-metadata.json"
+                                                                           data-error="Please input Metadata URL"
+                                                                           value="{{ SETTING.get('google_oauth_metadata_url') }}">
+                                                                    <span class="help-block with-errors"></span>
+                                                                </div>
                                                                 <div class="form-group">
                                                                     <label for="google_token_url">Token URL</label>
                                                                     <input type="text" class="form-control"
@@ -761,9 +768,6 @@
                                                                            value="{{ SETTING.get('github_oauth_secret') }}">
                                                                     <span class="help-block with-errors"></span>
                                                                 </div>
-                                                            </fieldset>
-                                                            <fieldset>
-                                                                <legend>ADVANCE</legend>
                                                                 <div class="form-group">
                                                                     <label for="github_oauth_scope">Scope</label>
                                                                     <input type="text" class="form-control"
@@ -782,6 +786,16 @@
                                                                            placeholder="e.g. https://api.github.com/user"
                                                                            data-error="Please input API URL"
                                                                            value="{{ SETTING.get('github_oauth_api_url') }}">
+                                                                    <span class="help-block with-errors"></span>
+                                                                </div>
+                                                                <div class="form-group">
+                                                                    <label for="github_oauth_metadata_url">Metadata URL</label>
+                                                                    <input type="text" class="form-control"
+                                                                           name="github_oauth_metadata_url"
+                                                                           id="github_oauth_metadata_url"
+                                                                           placeholder="e.g. https://{yourDomain}/.well-known/oauth-metadata.json"
+                                                                           data-error="Please input Metadata URL"
+                                                                           value="{{ SETTING.get('github_oauth_metadata_url') }}">
                                                                     <span class="help-block with-errors"></span>
                                                                 </div>
                                                                 <div class="form-group">
@@ -893,9 +907,6 @@
                                                                            value="{{ SETTING.get('azure_oauth_secret') }}">
                                                                     <span class="help-block with-errors"></span>
                                                                 </div>
-                                                            </fieldset>
-                                                            <fieldset>
-                                                                <legend>ADVANCED</legend>
                                                                 <div class="form-group">
                                                                     <label for="azure_oauth_scope">Scope</label>
                                                                     <input type="text" class="form-control"
@@ -914,6 +925,16 @@
                                                                            placeholder="e.g. https://graph.microsoft.com/v1.0/"
                                                                            data-error="Please input API URL"
                                                                            value="{{ SETTING.get('azure_oauth_api_url') }}">
+                                                                    <span class="help-block with-errors"></span>
+                                                                </div>
+                                                                <div class="form-group">
+                                                                    <label for="azure_oauth_metadata_url">Metadata URL</label>
+                                                                    <input type="text" class="form-control"
+                                                                           name="azure_oauth_metadata_url"
+                                                                           id="azure_oauth_metadata_url"
+                                                                           placeholder="e.g. https://{yourDomain}/.well-known/oauth-metadata.json"
+                                                                           data-error="Please input Metadata URL"
+                                                                           value="{{ SETTING.get('azure_oauth_metadata_url') }}">
                                                                     <span class="help-block with-errors"></span>
                                                                 </div>
                                                                 <div class="form-group">
@@ -1223,6 +1244,17 @@
                                                                     <span class="help-block with-errors"></span>
                                                                 </div>
                                                                 <div class="form-group">
+                                                                    <label for="oidc_oauth_metadata_url">Metadata
+                                                                        URL</label>
+                                                                    <input type="text" class="form-control"
+                                                                           name="oidc_oauth_metadata_url"
+                                                                           id="oidc_oauth_metadata_url"
+                                                                           placeholder="e.g. https://oidc.com/login/oauth/.well-known/openid-configuration"
+                                                                           data-error="Please input Metadata URL"
+                                                                           value="{{ SETTING.get('oidc_oauth_metadata_url') }}">
+                                                                    <span class="help-block with-errors"></span>
+                                                                </div>
+                                                                <div class="form-group">
                                                                     <label for="oidc_oauth_token_url">Token URL</label>
                                                                     <input type="text" class="form-control"
                                                                            name="oidc_oauth_token_url"
@@ -1255,17 +1287,6 @@
                                                                     <span class="help-block with-errors"></span>
                                                                 </div>
                                                                 <div class="form-group">
-                                                                    <label for="oidc_oauth_metadata_url">Metadata
-                                                                        URL</label>
-                                                                    <input type="text" class="form-control"
-                                                                           name="oidc_oauth_metadata_url"
-                                                                           id="oidc_oauth_metadata_url"
-                                                                           placeholder="e.g. https://oidc.com/login/oauth/.well-known/openid-configuration"
-                                                                           data-error="Please input Metadata URL"
-                                                                           value="{{ SETTING.get('oidc_oauth_metadata_url') }}">
-                                                                    <span class="help-block with-errors"></span>
-                                                                </div>
-                                                                <div class="form-group">
                                                                     <label for="oidc_oauth_logout_url">Logout
                                                                         URL</label>
                                                                     <input type="text" class="form-control"
@@ -1278,7 +1299,7 @@
                                                                 </div>
                                                             </fieldset>
                                                             <fieldset>
-                                                                <legend>CLAIMS</legend>
+                                                                <legend>Claims</legend>
                                                                 <div class="form-group">
                                                                     <label for="oidc_oauth_username">Username</label>
                                                                     <input type="text" class="form-control"
@@ -1320,7 +1341,7 @@
                                                                 </div>
                                                             </fieldset>
                                                             <fieldset>
-                                                                <legend>ADVANCE</legend>
+                                                                <legend>Advanced</legend>
                                                                 <div class="form-group">
                                                                     <label for="oidc_oauth_account_name_property">Autoprovision
                                                                         Account Name property</label>


### PR DESCRIPTION
A new setting field has been added for each OAuth provider (Google, GitHub, and Microsoft) to allow the configuration of the server_metadata_url parameter of the authlib library being used for OAuth integration. The OpenID Connect OAuth provider already had this configuration option.