### PR TITLE
Upgrade lxml & python3-saml dependencies with workaround

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ gunicorn==20.1.0
 itsdangerous==2.1.2
 jsonschema[format]>=2.5.1,<4.0.0 # until https://github.com/Yelp/bravado-core/pull/385
 lima==0.5
-lxml==4.6.5
+--use-feature=no-binary-enable-wheel-cache lxml==4.9.0
 mysqlclient==2.0.1
 passlib==1.7.4
 #pyOpenSSL==22.1.0
@@ -33,7 +33,7 @@ pyasn1==0.4.8
 pyotp==2.8.0
 pytest==7.2.1
 python-ldap==3.4.3
-python3-saml==1.14.0
+python3-saml==1.15.0
 pytimeparse==1.1.8
 pytz==2022.7.1
 qrcode==7.3.1


### PR DESCRIPTION
Fixes Python 3.11 incompatibility using ancient lxml binary PyPI built against old libxml2.

This fixes #1442 and closes #1433.

The issue with python3-saml not working is because the binary lxml wheel is built against a different version of libxml2.

``--no-binary lxml`` can be used to fix this and python3-saml will work.

for references check these:
- https://github.com/onelogin/python3-saml/issues/292
- https://bugs.launchpad.net/lxml/+bug/1960668
- https://github.com/open-formulieren/open-forms/pull/2247

```
Tested on:
 - ubuntu:23.04 - WORKING
 - ubuntu:22.10 - WORKING
 - ubuntu:22.04 - WORKING
 - ubuntu:20.04 - WORKING
 - ubuntu:18.04 - NOT WORKING - pip usage error with -r requirements.txt
 - debian:10    - WORKING
 - debian:11    - WORKING
 - alpine:edge  - WORKING
 - alpine:3.17  - WORKING
 - alpine:3.16  - WORKING
 - alpine:3.15  - WORKING
 - alpine:3.14  - WORKING
 - rockylinux:9 - WORKING
 - rockylinux:8 - NOT WORKING - pip usage error with -r requirements.txt
 - almalinux:9  - WORKING
 - almalinux:8  - NOT WORKING - pip usage error with -r requirements.txt
 - fedora:36    - WORKING
 - fedora:37    - WORKING
 - fedora:38    - WORKING
 - fedora:39    - WORKING
```