### PR TITLE
Fix user confirmed column migration issue

### DIFF
--- a/migrations/versions/3f76448bb6de_add_user_confirmed_column.py
+++ b/migrations/versions/3f76448bb6de_add_user_confirmed_column.py
@@ -23,7 +23,7 @@ def upgrade():
     with op.batch_alter_table('user') as batch_op:
         user = sa.sql.table('user', sa.sql.column('confirmed'))
         batch_op.execute(user.update().values(confirmed=False))
-        batch_op.alter_column('confirmed', nullable=False)
+        batch_op.alter_column('confirmed', nullable=False, existing_type=sa.Boolean(), existing_nullable=True, existing_server_default=False)
 
 
 def downgrade():


### PR DESCRIPTION
This change fixes the migration on the `user` table, `confirmed` column to be compatible with PostgreSQL and MySQL databases.

Fixes #635 which introduced a breaking change for MySQL databases and resolves #1446.

```
Tested on:
- PostgreSQL:14 - WORKING
- PostgreSQL:15 - WORKING
- MariaDB:10.11 - WORKING
- MariaDB:10.10 - WORKING
- MariaDB:10.9  - WORKING
- MariaDB:10.8  - WORKING
- MariaDB:10.7  - WORKING
- MariaDB:10.6  - WORKING
- MariaDB:10.5  - WORKING
- MariaDB:10.3  - WORKING
```
