### PR TITLE
Implement password strength & complexity checking

### DIFF
--- a/powerdnsadmin/models/setting.py
+++ b/powerdnsadmin/models/setting.py
@@ -205,6 +205,14 @@ class Setting(db.Model):
         'deny_domain_override': False,
         'account_name_extra_chars': False,
         'gravatar_enabled': False,
+        'pwd_enforce_characters': False,
+        'pwd_min_len': 10,
+        'pwd_min_lowercase': 3,
+        'pwd_min_uppercase': 2,
+        'pwd_min_digits': 2,
+        'pwd_min_special': 1,
+        'pwd_enforce_complexity': False,
+        'pwd_min_complexity': 11
     }
 
     def __init__(self, id=None, name=None, value=None):

--- a/powerdnsadmin/routes/admin.py
+++ b/powerdnsadmin/routes/admin.py
@@ -1550,7 +1550,23 @@ def setting_authentication():
             local_db_enabled = True if request.form.get(
                 'local_db_enabled') else False
             signup_enabled = True if request.form.get(
-                'signup_enabled', ) else False
+                'signup_enabled') else False
+
+            pwd_enforce_characters = True if request.form.get('pwd_enforce_characters') else False
+            pwd_min_len = safe_cast(request.form.get('pwd_min_len', Setting().defaults["pwd_min_len"]), int,
+                                    Setting().defaults["pwd_min_len"])
+            pwd_min_lowercase = safe_cast(request.form.get('pwd_min_lowercase', Setting().defaults["pwd_min_lowercase"]), int,
+                                          Setting().defaults["pwd_min_lowercase"])
+            pwd_min_uppercase = safe_cast(request.form.get('pwd_min_uppercase', Setting().defaults["pwd_min_uppercase"]), int,
+                                          Setting().defaults["pwd_min_uppercase"])
+            pwd_min_digits = safe_cast(request.form.get('pwd_min_digits', Setting().defaults["pwd_min_digits"]), int,
+                                       Setting().defaults["pwd_min_digits"])
+            pwd_min_special = safe_cast(request.form.get('pwd_min_special', Setting().defaults["pwd_min_special"]), int,
+                                        Setting().defaults["pwd_min_special"])
+
+            pwd_enforce_complexity = True if request.form.get('pwd_enforce_complexity') else False
+            pwd_min_complexity = safe_cast(request.form.get('pwd_min_complexity', Setting().defaults["pwd_min_complexity"]), int,
+                                           Setting().defaults["pwd_min_complexity"])
 
             if not has_an_auth_method(local_db_enabled=local_db_enabled):
                 result = {
@@ -1562,7 +1578,19 @@ def setting_authentication():
             else:
                 Setting().set('local_db_enabled', local_db_enabled)
                 Setting().set('signup_enabled', signup_enabled)
+
+                Setting().set('pwd_enforce_characters', pwd_enforce_characters)
+                Setting().set('pwd_min_len', pwd_min_len)
+                Setting().set('pwd_min_lowercase', pwd_min_lowercase)
+                Setting().set('pwd_min_uppercase', pwd_min_uppercase)
+                Setting().set('pwd_min_digits', pwd_min_digits)
+                Setting().set('pwd_min_special', pwd_min_special)
+
+                Setting().set('pwd_enforce_complexity', pwd_enforce_complexity)
+                Setting().set('pwd_min_complexity', pwd_min_complexity)
+
                 result = {'status': True, 'msg': 'Saved successfully'}
+
         elif conf_type == 'ldap':
             ldap_enabled = True if request.form.get('ldap_enabled') else False
 
@@ -2144,3 +2172,10 @@ def validateURN(value):
         return False
 
     return True
+
+
+def safe_cast(val, to_type, default=None):
+    try:
+        return to_type(val)
+    except (ValueError, TypeError):
+        return default

--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -788,6 +788,10 @@ def register():
         email=email
       )
 
+      (password_policy_pass, password_policy) = password_policy_check(user, password)
+      if not password_policy_pass:
+        return render_template('register.html', error_messages=password_policy, captcha_enable=CAPTCHA_ENABLE)
+
       try:
         result = user.create_local_user()
         if result and result['status']:

--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -5,6 +5,8 @@ import traceback
 import datetime
 import ipaddress
 import base64
+import string
+from zxcvbn import zxcvbn
 from distutils.util import strtobool
 from yaml import Loader, load
 from flask import Blueprint, render_template, make_response, url_for, current_app, g, session, request, redirect, abort
@@ -647,6 +649,92 @@ def logout():
         return res
 
     return redirect(redirect_uri)
+
+
+def password_policy_check(user, password):
+
+    def check_policy(chars, user_password, setting):
+        lenreq = int(Setting().get(setting))
+        test_string = user_password
+        for c in chars:
+            test_string = test_string.replace(c, '')
+        return (lenreq, len(user_password) - len(test_string))
+
+    def matches_policy(item, policy_fails):
+        return "*" if item in policy_fails else ""
+
+    policy = []
+    policy_fails = {}
+
+    # If either policy is enabled check basics first ... this is obvious!
+    if Setting().get('pwd_enforce_characters') or Setting().get('pwd_enforce_complexity'):
+        # Cannot contain username
+        if user.username in password:
+            policy_fails["username"] = True
+        policy.append(f"{matches_policy('username', policy_fails)}cannot contain username")
+
+        # Cannot contain password
+        if user.firstname in password:
+            policy_fails["firstname"] = True
+        policy.append(f"{matches_policy('firstname', policy_fails)}cannot contain firstname")
+
+        # Cannot contain lastname
+        if user.lastname in password:
+            policy_fails["lastname"] = True
+        policy.append(f"{matches_policy('lastname', policy_fails)}cannot contain lastname")
+
+        # Cannot contain email
+        if user.email in password:
+            policy_fails["email"] = True
+        policy.append(f"{matches_policy('email', policy_fails)}cannot contain email")
+
+    # Check if we're enforcing character requirements
+    if Setting().get('pwd_enforce_characters'):
+        # Length
+        pwd_min_len_setting = int(Setting().get('pwd_min_len'))
+        pwd_len = len(password)
+        if pwd_len < pwd_min_len_setting:
+            policy_fails["length"] = True
+        policy.append(f"{matches_policy('length', policy_fails)}length={pwd_len}/{pwd_min_len_setting}")
+        # Digits
+        (pwd_min_digits_setting, pwd_digits) = check_policy(string.digits, password, 'pwd_min_digits')
+        if pwd_digits < pwd_min_digits_setting:
+            policy_fails["digits"] = True
+        policy.append(f"{matches_policy('digits', policy_fails)}digits={pwd_digits}/{pwd_min_digits_setting}")
+        # Lowercase
+        (pwd_min_lowercase_setting, pwd_lowercase) = check_policy(string.digits, password, 'pwd_min_lowercase')
+        if pwd_lowercase < pwd_min_lowercase_setting:
+            policy_fails["lowercase"] = True
+        policy.append(f"{matches_policy('lowercase', policy_fails)}lowercase={pwd_lowercase}/{pwd_min_lowercase_setting}")
+        # Uppercase
+        (pwd_min_uppercase_setting, pwd_uppercase) = check_policy(string.digits, password, 'pwd_min_uppercase')
+        if pwd_uppercase < pwd_min_uppercase_setting:
+            policy_fails["uppercase"] = True
+        policy.append(f"{matches_policy('uppercase', policy_fails)}uppercase={pwd_uppercase}/{pwd_min_uppercase_setting}")
+        # Special
+        (pwd_min_special_setting, pwd_special) = check_policy(string.digits, password, 'pwd_min_special')
+        if pwd_special < pwd_min_special_setting:
+            policy_fails["special"] = True
+        policy.append(f"{matches_policy('special', policy_fails)}special={pwd_special}/{pwd_min_special_setting}")
+
+    if Setting().get('pwd_enforce_complexity'):
+        # Complexity checking
+        zxcvbn_inputs = []
+        for input in (user.firstname, user.lastname, user.username, user.email):
+            if len(input):
+                zxcvbn_inputs.append(input)
+
+        result = zxcvbn(password, user_inputs=zxcvbn_inputs)
+        pwd_min_complexity_setting = int(Setting().get('pwd_min_complexity'))
+        pwd_complexity = result['guesses_log10']
+        if pwd_complexity < pwd_min_complexity_setting:
+            policy_fails["complexity"] = True
+        policy.append(f"{matches_policy('complexity', policy_fails)}complexity={pwd_complexity:.0f}/{pwd_min_complexity_setting}")
+
+    policy_str = {"password": f"Fails policy: {', '.join(policy)}. Items prefixed with '*' failed."}
+
+    # NK: the first item in the tuple indicates a PASS, so, we check for any True's and negate that
+    return (not any(policy_fails.values()), policy_str)
 
 
 @index_bp.route('/register', methods=['GET', 'POST'])

--- a/powerdnsadmin/templates/admin_setting_authentication.html
+++ b/powerdnsadmin/templates/admin_setting_authentication.html
@@ -78,24 +78,89 @@
                                                             <h3 class="card-title">Basic Settings</h3>
                                                         </div>
                                                         <!-- /.card-header -->
-                                                        <div class="card-body">
-                                                            <div class="form-group">
-                                                                <input type="checkbox" id="local_db_enabled"
-                                                                       name="local_db_enabled"
-                                                                       class="checkbox"
-                                                                       {% if SETTING.get('local_db_enabled') %}checked{% endif %}>
-                                                                <label for="local_db_enabled">Local DB
-                                                                    Authentication</label>
+                                                        <fieldset>
+                                                            <div class="card-body">
+                                                                <div class="form-group">
+                                                                    <input type="checkbox" id="local_db_enabled"
+                                                                        name="local_db_enabled"
+                                                                        class="checkbox"
+                                                                        {% if SETTING.get('local_db_enabled') %}checked{% endif %}>
+                                                                    <label for="local_db_enabled">Local DB
+                                                                        Authentication</label>
+                                                                </div>
+                                                                <div class="form-group">
+                                                                    <input type="checkbox" id="signup_enabled"
+                                                                        name="signup_enabled"
+                                                                        class="checkbox"
+                                                                        {% if SETTING.get('signup_enabled') %}checked{% endif %}>
+                                                                    <label for="signup_enabled">Allow users to sign
+                                                                        up</label>
+                                                                </div>
                                                             </div>
-                                                            <div class="form-group">
-                                                                <input type="checkbox" id="signup_enabled"
-                                                                       name="signup_enabled"
-                                                                       class="checkbox"
-                                                                       {% if SETTING.get('signup_enabled') %}checked{% endif %}>
-                                                                <label for="signup_enabled">Allow users to sign
-                                                                    up</label>
+                                                        </fieldset>
+                                                        <fieldset>
+                                                            <legend>PASSWORD REQUIREMENTS</legend>
+                                                            <div class="card-body">
+                                                                <div class="form-group">
+                                                                    <input type="checkbox" id="pwd_enforce_characters"
+                                                                        name="pwd_enforce_characters" class="checkbox"
+                                                                        {% if SETTING.get('pwd_enforce_characters') %}checked{% endif %}>
+                                                                    <label for="pwd_enforce_characters">
+                                                                        Enforce Character Requirements
+                                                                    </label>
+                                                                </div>
+                                                                <div class="form-group">
+                                                                    <label for="pwd_min_len">Minimum Password Length</label>
+                                                                    <input type="text" class="form-control"
+                                                                        name="pwd_min_len" id="pwd_min_len"
+                                                                        data-error="Please enter a minimum password length"
+                                                                        value="{{ SETTING.get('pwd_min_len') }}">
+                                                                </div>
+                                                                <div class="form-group">
+                                                                    <label for="pwd_min_lowercase">Minimum Lowercase Characters</label>
+                                                                    <input type="text" class="form-control"
+                                                                        name="pwd_min_lowercase" id="pwd_min_lowercase"
+                                                                        data-error="Please enter the minimum number of lowercase letters required"
+                                                                        value="{{ SETTING.get('pwd_min_lowercase') }}">
+                                                                </div>
+                                                                <div class="form-group">
+                                                                    <label for="pwd_min_uppercase">Minimum Uppercase Characters</label>
+                                                                    <input type="text" class="form-control"
+                                                                        name="pwd_min_uppercase" id="pwd_min_uppercase"
+                                                                        data-error="Please enter the minimum number of uppercase letters required"
+                                                                        value="{{ SETTING.get('pwd_min_uppercase') }}">
+                                                                </div>
+                                                                <div class="form-group">
+                                                                    <label for="pwd_min_digits">Minimum Digit Characters</label>
+                                                                    <input type="text" class="form-control"
+                                                                        name="pwd_min_digits" id="pwd_min_digits"
+                                                                        data-error="Please enter the minimum number of digits required"
+                                                                        value="{{ SETTING.get('pwd_min_digits') }}">
+                                                                </div>
+                                                                <div class="form-group">
+                                                                    <label for="pwd_min_special">Minimum Special Characters</label>
+                                                                    <input type="text" class="form-control"
+                                                                        name="pwd_min_special" id="pwd_min_special"
+                                                                        data-error="Please enter the minimum number of special characters required"
+                                                                        value="{{ SETTING.get('pwd_min_special') }}">
+                                                                </div>
+                                                                <div class="form-group">
+                                                                    <input type="checkbox" id="pwd_enforce_complexity"
+                                                                        name="pwd_enforce_complexity" class="checkbox"
+                                                                        {% if SETTING.get('pwd_enforce_complexity') %}checked{% endif %}>
+                                                                    <label for="pwd_enforce_complexity">
+                                                                        Enforce Complexity Requirement
+                                                                    </label>
+                                                                </div>
+                                                                <div class="form-group">
+                                                                    <label for="pwd_min_complexity">Minimum Complexity (zxcvbn)</label>
+                                                                    <input type="text" class="form-control"
+                                                                        name="pwd_min_complexity" id="pwd_min_complexity"
+                                                                        data-error="Please enter the minimum password complexity required"
+                                                                        value="{{ SETTING.get('pwd_min_complexity') }}">
+                                                                </div>
                                                             </div>
-                                                        </div>
+                                                        </fieldset>
                                                         <!-- /.card-body -->
                                                         <div class="card-footer">
                                                             <button type="submit" class="btn btn-primary"
@@ -117,7 +182,49 @@
                                                     </div>
                                                     <!-- /.card-header -->
                                                     <div class="card-body">
-                                                        <p>Fill in all the fields in the left form.</p>
+                                                        <dl class="dl-horizontal">
+                                                            <dt>Local DB Authentication</dt>
+                                                            <dd>Enable/disable local database authentication.</dd>
+                                                            <dt>Allow Users to Signup</dt>
+                                                            <dd>Allow users to signup. This requires local database authentication
+                                                                to be enabled.</dd>
+                                                            <legend>PASSWORD REQUIREMENTS</legend>
+                                                            This section allows you to customize your local DB password requirements
+                                                            and ensure that when users change their password or signup they are
+                                                            picking strong passwords.
+                                                            <br/>
+                                                            Setting any entry field to a blank value will revert it back to default.
+
+                                                            <dt>Enforce Character Requirements</dt>
+                                                            <dd>This option will enforce the character type requirements for
+                                                                passwords.
+                                                                <ul>
+                                                                    <li>Minimum Lowercase Characters - Minimum number of lowercase
+                                                                        characters required to appear in the password.</li>
+                                                                    <li>Minimum Uppercase Characters - Minimum number of uppercase
+                                                                        characters required to appear in the password.</li>
+                                                                    <li>Minimum Digit Characters - Minimum number of digits
+                                                                        required to appear in the password. Digits include
+                                                                        1234567890.</li>
+                                                                    <li>Minimum Special Characters - Minimum number of special
+                                                                        characters required to appear in the password. Special
+                                                                        characters include
+                                                                        `!@#$%^&amp;*()_-=+[]\{}|;:",.&gt;&lt;/?.</li>
+                                                                </ul>
+                                                            </dd>
+                                                            <dt>Enforce Complexity Requirement</dt>
+                                                            <dd>Enable the enforcement of complex passwords. We currently use
+                                                                <a href="https://github.com/dropbox/zxcvbn">zxcvbn</a> for
+                                                                determining this.
+                                                                <ul>
+                                                                    <li>Minimum Complexity - The default value of the log factor
+                                                                        is 11 as it is considered secure. More information about
+                                                                        the this can be found at
+                                                                        <a href="https://www.usenix.org/system/files/conference/usenixsecurity16/sec16_paper_wheeler.pdf">here</a>
+                                                                    </li>
+                                                                </ul>
+                                                            </dd>
+                                                        </dl>
                                                     </div>
                                                     <!-- /.card-body -->
                                                 </div>

--- a/powerdnsadmin/templates/user_profile.html
+++ b/powerdnsadmin/templates/user_profile.html
@@ -34,13 +34,13 @@
                             <div class="nav-tabs-custom mb-2">
                                 <ul class="nav nav-tabs" role="tablist">
                                     <li class="nav-item">
-                                        <a class="nav-link active" href="#tabs-personal" data-toggle="tab">
+                                        <a class="nav-link {{ 'active' if not error_messages else '' }}" href="#tabs-personal" data-toggle="tab">
                                             Personal Info
                                         </a>
                                     </li>
                                     {% if session['authentication_type'] == 'LOCAL' %}
                                         <li class="nav-item">
-                                            <a class="nav-link" href="#tabs-password" data-toggle="tab">
+                                            <a class="nav-link {{ 'active' if 'password' in error_messages else '' }}" href="#tabs-password" data-toggle="tab">
                                                 Change Password
                                             </a>
                                         </li>
@@ -57,7 +57,8 @@
                             <!-- /.nav-tabs-custom -->
 
                             <div class="tab-content">
-                                <div class="tab-pane fade show active" id="tabs-personal">
+                                <div class="tab-pane fade {{ 'show active' if not error_messages else '' }}"
+                                        id="tabs-personal">
                                     <form role="form" method="post" action="{{ user_profile }}">
                                         <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
                                         <div class="form-group">
@@ -91,7 +92,8 @@
                                 <!-- /.tab-pane -->
 
                                 {% if session['authentication_type'] == 'LOCAL' %}
-                                    <div class="tab-pane fade" id="tabs-password">
+                                    <div class="tab-pane fade {{ 'show active' if 'password' in error_messages else '' }}"
+                                            id="tabs-password">
                                         {% if not current_user.password %}
                                             Your account password is managed via LDAP which isn't supported to
                                             change here.
@@ -101,8 +103,15 @@
                                                        value="{{ csrf_token() }}">
                                                 <div class="form-group">
                                                     <label for="password">New Password</label>
-                                                    <input type="password" class="form-control" name="password"
+                                                    <input type="password" class="form-control {{ 'is-invalid' if 'password' in error_messages else '' }}"
+                                                           name="password"
                                                            id="newpassword">
+                                                    {% if 'password' in error_messages %}
+                                                    <div class="invalid-feedback">
+                                                        <i class="fas fa-exclamation-triangle"></i>
+                                                        {{ error_messages['password'] }}
+                                                    </div>
+                                                    {% endif %}
                                                 </div>
                                                 <div class="form-group">
                                                     <label for="rpassword">Re-type New Password</label>

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ webcolors==1.12
 werkzeug==2.1.2
 zipp==3.11.0
 rcssmin==1.1.1
+zxcvbn==4.4.28


### PR DESCRIPTION
Closes #989

I completely re-implemented https://github.com/PowerDNS-Admin/PowerDNS-Admin/pull/1054, which can be closed if this is merged. I did keep the values that were used as defaults.

Password policies are **opt-in** so we don't affect current installations.

I added password strength and complexity checking in a way it allows you to pick either or both of the methods, namely password character requirement counts and password complexity based on zxcvbn.

If either method is active, restrictions on using the username, password, email address, first name, last name will be set in place. I'm sure we can all agree unanimously on that!

I added help to the right hand side for the "Basic" tab in the "Authentication" settings to help with the fields being entered in.

Blanking the any password policy setting will return it to its default value.

I added password policy checking to user registration and user profile page, as far as I can see this is the only two places the password can be set.

When using a password which does not meet the policy defined in settings, the policy will be displayed along with a `*` for each item which fails to assist in indicating what must be fixed. I think its a good start, I couldn't think of an easier more appealing way to indicate failure on a per-requirement basis.

Only one requirement added to requirements.txt, which is `zxcvnb`.

The changes are pretty simple and straight forward, I tried to keep the patch as clean as possible to assist with review.

I tested each of the password policies, enabling/disabling each method along with testing each policy is honored.

I'd appreciate any testing from the community, but I'd say its ready for merge and if anyone has any issue with the functionality I'll gladly attend.

```
zxcvnb requirement tested on:
    "ubuntu:23.04"
    "ubuntu:22.10"
    "ubuntu:22.04"
    "ubuntu:20.04"
    "debian:10"
    "debian:11"
    "alpine:edge"
    "alpine:3.17"
    "alpine:3.16"
    "alpine:3.15"
    "alpine:3.14"
    "rockylinux:9"
    "almalinux:9"
    "fedora:36"
    "fedora:37"
    "fedora:38"
    "fedora:39"
```

![pass3](https://user-images.githubusercontent.com/2354782/225809375-2c8d9ae1-de3e-4aa2-bf25-1a480217661d.png)
![pass1](https://user-images.githubusercontent.com/2354782/225809397-18dd4d74-614d-4f61-b4c7-73caf49f1f90.png)
![pass2](https://user-images.githubusercontent.com/2354782/225809409-cabbf0c5-913d-4335-b3c3-f8dc77e6aed8.png)
