### PR TITLE
Fix manual session clearing that triggered session expiration bug

### DIFF
--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -528,7 +528,6 @@ def clear_session():
     session.pop('google_token', None)
     session.pop('authentication_type', None)
     session.pop('remote_user', None)
-    session.clear()
     logout_user()
 
 


### PR DESCRIPTION
It seems when logging in and logging out, then logging back in, setting the session timeout to 5 minutes, then waiting for expiry can cause a situation when using SQLA-based sessions which results in a NULL field in the database and causes a persistent 500 Internal Server Error.

As per issue 1439 here is a fix found by @raunz.

Resolves #1439.

Tested for about 8 hours and tons and tons of expired sessions, could not reproduce with the fix applied.