### PR TITLE
Feature Update: Allow more than 100 rows in the zone list view.

### DIFF
--- a/powerdnsadmin/routes/dashboard.py
+++ b/powerdnsadmin/routes/dashboard.py
@@ -141,7 +141,7 @@ def domains_custom(tab_id):
     filtered_count = domains.count()
 
     start = int(request.args.get("start", 0))
-    length = min(int(request.args.get("length", 0)), 100)
+    length = min(int(request.args.get("length", 0)), max(100, int(Setting().get('default_domain_table_size'))))
 
     if length != -1:
         domains = domains[start:start + length]


### PR DESCRIPTION
The dashboard.domains_custom route was hardcoded to either return all the domains, or at most 100, regardless of default_domain_table_size setting.

Make this limit be dependent on default_domain_table_size instead.

The API will now limit to 100 or default_domain_table_size, whichever one is higher. This is done to not break any seconday use-cases that might depend on the hardcoded setting.

<!--
    Thank you for your interest in contributing to the PowerDNS Admin project! Please note that our contribution
    policy requires that a feature request or bug report be approved and assigned prior to opening a pull request.
    This helps avoid wasted time and effort on a proposed change that we might want to or be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED TO YOU, IT WILL BE CLOSED AUTOMATICALLY!

    Please specify your assigned issue number on the line below.
-->
### Fixes: #1485 

<!--
    Please include a summary of the proposed changes below.
-->