### PR TITLE
Fix Zone Type can not be changed from "native" when adding or modifying zones

### DIFF
--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -66,7 +66,7 @@ def domain(domain_name):
     current_app.logger.debug("Fetched rrsets: \n{}".format(pretty_json(rrsets)))
 
     # API server might be down, misconfigured
-    if not rrsets and domain.type != 'Slave':
+    if not rrsets and domain.type != 'slave':
         abort(500)
 
     quick_edit = Setting().get('record_quick_edit')
@@ -206,7 +206,7 @@ def changelog(domain_name):
     current_app.logger.debug("Fetched rrsets: \n{}".format(pretty_json(rrsets)))
 
     # API server might be down, misconfigured
-    if not rrsets and domain.type != 'Slave':
+    if not rrsets and domain.type != 'slave':
         abort(500)
 
     records_allow_to_edit = Setting().get_records_allow_to_edit()
@@ -294,7 +294,7 @@ def record_changelog(domain_name, record_name, record_type):
     current_app.logger.debug("Fetched rrsets: \n{}".format(pretty_json(rrsets)))
 
     # API server might be down, misconfigured
-    if not rrsets and domain.type != 'Slave':
+    if not rrsets and domain.type != 'slave':
         abort(500)
 
     # get all changelogs for this domain, in descening order

--- a/powerdnsadmin/templates/domain_add.html
+++ b/powerdnsadmin/templates/domain_add.html
@@ -76,10 +76,15 @@
                                     <div class="radio">
                                         <label>
                                             <input type="radio" name="radio_type" id="radio_type_secondary"
-                                                   value="secondary">
+                                                   value="slave">
                                             Secondary
                                         </label>
                                     </div>
+                                </div>
+                                <div class="form-group" style="display: none;" id="domain_master_address_div">
+                                    <input type="text" class="form-control" name="domain_master_address"
+                                           id="domain_master_address"
+                                           placeholder="Enter valid Primary Server IP addresses (separated by commas)">
                                 </div>
                                 <div class="form-group">
                                     <label for="domain_template">Zone Template</label>
@@ -89,11 +94,6 @@
                                             <option value="{{ template.id }}">{{ template.name }}</option>
                                         {% endfor %}
                                     </select>
-                                </div>
-                                <div class="form-group" style="display: none;" id="domain_primary_address_div">
-                                    <input type="text" class="form-control" name="domain_primary_address"
-                                           id="domain_primary_address"
-                                           placeholder="Enter valid Primary Server IP addresses (separated by commas)">
                                 </div>
                                 <div class="form-group">
                                     <label>SOA-EDIT-API</label>
@@ -228,10 +228,10 @@
     <script>
         $("input[name=radio_type]").change(function () {
             var type = $(this).val();
-            if (type == "secondary") {
-                $("#domain_primary_address_div").show();
+            if (type == "slave") {
+                $("#domain_master_address_div").show();
             } else {
-                $("#domain_primary_address_div").hide();
+                $("#domain_master_address_div").hide();
             }
         });
     </script>

--- a/powerdnsadmin/templates/domain_setting.html
+++ b/powerdnsadmin/templates/domain_setting.html
@@ -220,12 +220,12 @@
                                 <select name="domain_type" class="form-control" style="width:15em;">
                                     <option selected value="0">- Unchanged -</option>
                                     <option value="native">Native</option>
-                                    <option value="primary">Primary</option>
-                                    <option value="secondary">Secondary</option>
+                                    <option value="master">Primary</option>
+                                    <option value="slave">Secondary</option>
                                 </select><br/>
-                                <div class="form-group" style="display: none;" id="domain_primary_address_div">
-                                    <input type="text" class="form-control" name="domain_primary_address"
-                                           id="domain_primary_address"
+                                <div class="form-group" style="display: none;" id="domain_master_address_div">
+                                    <input type="text" class="form-control" name="domain_master_address"
+                                           id="domain_master_address"
                                            placeholder="Enter valid Primary Server IP addresses (separated by commas)">
                                 </div>
                                 <button type="submit" title="Update Zone Type" class="btn btn-primary" id="change_type">
@@ -422,10 +422,10 @@
         // zone primary address input handeling
         $("select[name=domain_type]").change(function () {
             var type = $(this).val();
-            if (type == "secondary") {
-                $("#domain_primary_address_div").show();
+            if (type == "slave") {
+                $("#domain_master_address_div").show();
             } else {
-                $("#domain_primary_address_div").hide();
+                $("#domain_master_address_div").hide();
             }
         });
 


### PR DESCRIPTION
### Fixes: #1501 

<!--
    Please include a summary of the proposed changes below.
-->
This PR makes it possible to use a different Zone Type than "native". It also moves the input field for primary IP's just below the Secondary radio button when adding a zone. This makes it more clear that this field is related to the zone being a secondary.