### PR TITLE
Fixed issue with all unassigned zones being selected after a new account's name fails to validate

### DIFF
--- a/powerdnsadmin/templates/admin_edit_account.html
+++ b/powerdnsadmin/templates/admin_edit_account.html
@@ -133,7 +133,7 @@
                                                     </option>
                                                 {% endwith %}
                                             {% else %}
-                                                <option {% if account.id == domain.account_id %}selected{% endif %}
+                                                <option {% if account.id and account.id == domain.account_id %}selected{% endif %}
                                                         value="{{ domain.name }}">
                                                     {{ domain.name }}
                                                 </option>


### PR DESCRIPTION
…use all unassigned zones to be selected automatically following the attempt of account creation with an invalid name.

<!--
    Thank you for your interest in contributing to the PowerDNS Admin project! Please note that our contribution
    policy requires that a feature request or bug report be approved and assigned prior to opening a pull request.
    This helps avoid wasted time and effort on a proposed change that we might want to or be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED TO YOU, IT WILL BE CLOSED AUTOMATICALLY!

    Please specify your assigned issue number on the line below.
-->
### Fixes: #1495

<!--
    Please include a summary of the proposed changes below.
-->