### PR TITLE
Do not use hard coded userinfo URL

### DIFF
--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -163,7 +163,7 @@ def login():
         return redirect(url_for('dashboard.dashboard'))
 
     if 'google_token' in session:
-        user_data = json.loads(google.get('userinfo').text)
+        user_data = google.userinfo()
         google_first_name = user_data['given_name']
         google_last_name = user_data['family_name']
         google_email = user_data['email']
@@ -187,7 +187,7 @@ def login():
         return authenticate_user(user, 'Google OAuth')
 
     if 'github_token' in session:
-        user_data = json.loads(github.get('user').text)
+        user_data = github.userinfo()
         github_username = user_data['login']
         github_first_name = user_data['name']
         github_last_name = ''
@@ -392,7 +392,7 @@ def login():
         return authenticate_user(user, 'Azure OAuth')
 
     if 'oidc_token' in session:
-        user_data = json.loads(oidc.get('userinfo').text)
+        user_data = oidc.userinfo()
         oidc_username = user_data[Setting().get('oidc_oauth_username')]
         oidc_first_name = user_data[Setting().get('oidc_oauth_firstname')]
         oidc_last_name = user_data[Setting().get('oidc_oauth_last_name')]


### PR DESCRIPTION
### Fixes: #1614

Use Authlib Userinfo class to call the userinfo URL for OIDC, Google and Github OAuth