### PR TITLE
Correct OIDC logout to properly support Keycloak

### DIFF
--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -652,10 +652,11 @@ def logout():
 
     redirect_uri = url_for('index.login')
     oidc_logout = Setting().get('oidc_oauth_logout_url')
+    id_token_hint = session.get('oidc_token').get('id_token', None)
 
-    if 'oidc_token' in session and oidc_logout:
-        redirect_uri = "{}?redirect_uri={}".format(
-            oidc_logout, url_for('index.login', _external=True))
+    if id_token_hint and oidc_logout:
+        redirect_uri = "{}?post_logout_redirect_uri={}&id_token_hint={}".format(
+            url_for('index.login', _external=True), oidc_logout, id_token_hint)
 
     # Clean cookies and flask session
     clear_session()

--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -652,7 +652,7 @@ def logout():
 
     redirect_uri = url_for('index.login')
     oidc_logout = Setting().get('oidc_oauth_logout_url')
-    id_token_hint = session.get('oidc_token').get('id_token', None)
+    id_token_hint = session.get('oidc_token').get('id_token')
 
     if id_token_hint and oidc_logout:
         redirect_uri = "{}?post_logout_redirect_uri={}&id_token_hint={}".format(


### PR DESCRIPTION
Keycloak expects these two values:

post_logout_redirect_uri (and not redirect_uri)
id_token_hint (which is recommended by the spec: https://openid.net/specs/openid-connect-rpinitiated-1_0.html, but required by keycloak)

Tested on Keycloak version: 20.0.5

Fixes https://github.com/PowerDNS-Admin/PowerDNS-Admin/issues/1222