### PR TITLE
Fixes local user setup to perform case-insensitive verification of existing usernames / emails

### DIFF
--- a/powerdnsadmin/models/user.py
+++ b/powerdnsadmin/models/user.py
@@ -408,7 +408,7 @@ class User(db.Model):
         Create local user witch stores username / password in the DB
         """
         # check if username existed
-        user = User.query.filter(User.username == self.username).first()
+        user = User.query.filter(User.username.lower() == self.username.lower()).first()
         if user:
             return {'status': False, 'msg': 'Username is already in use'}
 

--- a/powerdnsadmin/models/user.py
+++ b/powerdnsadmin/models/user.py
@@ -413,7 +413,7 @@ class User(db.Model):
             return {'status': False, 'msg': 'Username is already in use'}
 
         # check if email existed
-        user = User.query.filter(User.email == self.email).first()
+        user = User.query.filter(User.email.lower() == self.email.lower()).first()
         if user:
             return {'status': False, 'msg': 'Email address is already in use'}
 

--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -258,7 +258,7 @@ def login():
 
             result = user.create_local_user()
             if not result['status']:
-                current_app.logger.warning('Unable to create ' + azure_username)
+                current_app.logger.warning('Unable to create ' + azure_username + ' Reasoning: ' + result['msg'])
                 session.pop('azure_token', None)
                 # note: a redirect to login results in an endless loop, so render the login page instead
                 return render_template('login.html',


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to the PowerDNS Admin project! Please note that our contribution
    policy requires that a feature request or bug report be approved and assigned prior to opening a pull request.
    This helps avoid wasted time and effort on a proposed change that we might want to or be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED TO YOU, IT WILL BE CLOSED AUTOMATICALLY!

    Please specify your assigned issue number on the line below.
-->
### Fixes: #1657 

<!--
    Please include a summary of the proposed changes below.
-->
I have updated the create_local_user() function to be case sensitive when checking the database for existing users with the same username and/or email. Additionally, when this function fails it returns its result status and message, as this message is useful for debugging, I have added it to the log message.