### PR TITLE
Update index router to replace the use of the deprecated `before_app_first_request` event with `record_once`

### DIFF
--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -46,7 +46,7 @@ index_bp = Blueprint('index',
                      url_prefix='/')
 
 
-@index_bp.before_app_first_request
+@index_bp.record_once
 def register_modules():
     global google
     global github


### PR DESCRIPTION
### Fixes: #1686

I updated the `powerdnsadmin/routes/index.py` router method `register_modules` to use the `Blueprint.record_once` event in-place of the deprecated `Blueprint.before_app_first_request` event.