### PR TITLE
Updated zone type comparison logic in domain router to be case-insensitive

### DIFF
--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -66,7 +66,7 @@ def domain(domain_name):
     current_app.logger.debug("Fetched rrsets: \n{}".format(pretty_json(rrsets)))
 
     # API server might be down, misconfigured
-    if not rrsets and domain.type != 'slave':
+    if not rrsets and str(domain.type).lower() != 'slave':
         abort(500)
 
     quick_edit = Setting().get('record_quick_edit')


### PR DESCRIPTION
### Fixes: #1639

I updated the line `if not rrsets and domain.type != 'slave':` in `powerdnsadmin/routes/domain.py` to be `if not rrsets and str(domain.type).lower() != 'slave':` in order to resolve false positives due to case differences in the referenced values.