### PR TITLE
Fix zone name encoding for UI XHR requests as well as requests to the PDNS API

### DIFF
--- a/powerdnsadmin/models/domain.py
+++ b/powerdnsadmin/models/domain.py
@@ -643,6 +643,8 @@ class Domain(db.Model):
         """
         Update records from Master DNS server
         """
+        import urllib.parse
+
         domain = Domain.query.filter(Domain.name == domain_name).first()
         if domain:
             headers = {'X-API-Key': self.PDNS_API_KEY}
@@ -650,7 +652,7 @@ class Domain(db.Model):
                 r = utils.fetch_json(urljoin(
                     self.PDNS_STATS_URL, self.API_EXTENDED_URL +
                                          '/servers/localhost/zones/{0}/axfr-retrieve'.format(
-                                             domain.name)),
+                                             urllib.parse.quote_plus(domain.name))),
                     headers=headers,
                     timeout=int(
                         Setting().get('pdns_api_timeout')),
@@ -673,6 +675,8 @@ class Domain(db.Model):
         """
         Get zone DNSSEC information
         """
+        import urllib.parse
+
         domain = Domain.query.filter(Domain.name == domain_name).first()
         if domain:
             headers = {'X-API-Key': self.PDNS_API_KEY}
@@ -681,7 +685,7 @@ class Domain(db.Model):
                     urljoin(
                         self.PDNS_STATS_URL, self.API_EXTENDED_URL +
                                              '/servers/localhost/zones/{0}/cryptokeys'.format(
-                                                 domain.name)),
+                                                 urllib.parse.quote_plus(domain.name))),
                     headers=headers,
                     timeout=int(Setting().get('pdns_api_timeout')),
                     method='GET',
@@ -709,6 +713,8 @@ class Domain(db.Model):
         """
         Enable zone DNSSEC
         """
+        import urllib.parse
+
         domain = Domain.query.filter(Domain.name == domain_name).first()
         if domain:
             headers = {'X-API-Key': self.PDNS_API_KEY, 'Content-Type': 'application/json'}
@@ -718,7 +724,9 @@ class Domain(db.Model):
                 jdata = utils.fetch_json(
                     urljoin(
                         self.PDNS_STATS_URL, self.API_EXTENDED_URL +
-                                             '/servers/localhost/zones/{0}'.format(domain.name)),
+                                             '/servers/localhost/zones/{0}'.format(
+                                                 urllib.parse.quote_plus(domain.name)
+                                             )),
                     headers=headers,
                     timeout=int(Setting().get('pdns_api_timeout')),
                     method='PUT',
@@ -738,7 +746,8 @@ class Domain(db.Model):
                     urljoin(
                         self.PDNS_STATS_URL, self.API_EXTENDED_URL +
                                              '/servers/localhost/zones/{0}/cryptokeys'.format(
-                                                 domain.name)),
+                                                 urllib.parse.quote_plus(domain.name)
+                                             )),
                     headers=headers,
                     timeout=int(Setting().get('pdns_api_timeout')),
                     method='POST',
@@ -775,6 +784,8 @@ class Domain(db.Model):
         """
         Remove keys DNSSEC
         """
+        import urllib.parse
+
         domain = Domain.query.filter(Domain.name == domain_name).first()
         if domain:
             headers = {'X-API-Key': self.PDNS_API_KEY, 'Content-Type': 'application/json'}
@@ -784,7 +795,7 @@ class Domain(db.Model):
                     urljoin(
                         self.PDNS_STATS_URL, self.API_EXTENDED_URL +
                                              '/servers/localhost/zones/{0}/cryptokeys/{1}'.format(
-                                                 domain.name, key_id)),
+                                                 urllib.parse.quote_plus(domain.name), key_id)),
                     headers=headers,
                     timeout=int(Setting().get('pdns_api_timeout')),
                     method='DELETE',

--- a/powerdnsadmin/static/custom/js/custom.js
+++ b/powerdnsadmin/static/custom/js/custom.js
@@ -30,14 +30,14 @@ function applyChanges(data, url, showResult, refreshPage) {
 function applyRecordChanges(data, domain) {
     $.ajax({
         type : "POST",
-        url : $SCRIPT_ROOT + '/domain/' + domain + '/apply',
+        url : $SCRIPT_ROOT + '/domain/' + encodeURIComponent(domain) + '/apply',
         data : JSON.stringify(data),// now data come in this function
         contentType : "application/json; charset=utf-8",
         crossDomain : true,
         dataType : "json",
         success : function(data, status, jqXHR) {
             // update Apply button value
-            $.getJSON($SCRIPT_ROOT + '/domain/' + domain + '/info', function(data) {
+            $.getJSON($SCRIPT_ROOT + '/domain/' + encodeURIComponent(domain) + '/info', function(data) {
                 $(".button_apply_changes").val(data['serial']);
             });
 

--- a/powerdnsadmin/templates/dashboard.html
+++ b/powerdnsadmin/templates/dashboard.html
@@ -181,17 +181,17 @@
         {% if current_user.role.name in ['Administrator', 'Operator'] or not SETTING.get('dnssec_admins_only') %}
             $(document.body).on("click", ".button_dnssec", function () {
                 var domain = $(this).prop('id');
-                getdnssec($SCRIPT_ROOT + '/domain/' + domain + '/dnssec', domain);
+                getdnssec($SCRIPT_ROOT + '/domain/' + encodeURIComponent(domain) + '/dnssec', domain);
             });
 
             $(document.body).on("click", ".button_dnssec_enable", function () {
                 var domain = $(this).prop('id');
-                enable_dns_sec($SCRIPT_ROOT + '/domain/' + domain + '/dnssec/enable', '{{ csrf_token() }}');
+                enable_dns_sec($SCRIPT_ROOT + '/domain/' + encodeURIComponent(domain) + '/dnssec/enable', '{{ csrf_token() }}');
             });
 
             $(document.body).on("click", ".button_dnssec_disable", function () {
                 var domain = $(this).prop('id');
-                enable_dns_sec($SCRIPT_ROOT + '/domain/' + domain + '/dnssec/disable', '{{ csrf_token() }}');
+                enable_dns_sec($SCRIPT_ROOT + '/domain/' + encodeURIComponent(domain) + '/dnssec/disable', '{{ csrf_token() }}');
             });
         {% endif %}
     </script>


### PR DESCRIPTION
### Fixes: #1630

I updated UI code for the dashboard view of zones as well as associated back-end methods to perform URL encoding on the zone name before using it in requests where the value is part of the URL path. The lack of this was causing zone names with forward slashes to fail during related requests.