### PR TITLE
Updated Pip Dependencies (Jinaj2, certifi, cryptography, requests, werkzeug)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,16 +8,16 @@ Flask-SSLify==0.1.5
 Flask-SeaSurf==1.1.1
 Flask-Session==0.4.0
 Flask==2.2.5
-Jinja2==3.1.2
+Jinja2==3.1.3
 PyYAML==6.0.1
 SQLAlchemy==1.4.51
 #alembic==1.9.0
 bcrypt==4.1.2
 bravado-core==5.17.1
-certifi==2022.12.7
+certifi==2023.11.17
 cffi==1.15.1
 configobj==5.0.8
-cryptography==39.0.2 # fixes CVE-2023-0286, CVE-2023-23931
+cryptography==42.0.2
 cssmin==0.2.0
 dnspython>=2.3.0
 flask_session_captcha==1.3.0
@@ -37,10 +37,10 @@ python3-saml==1.15.0
 pytimeparse==1.1.8
 pytz==2022.7.1
 qrcode==7.3.1
-requests==2.28.2
+requests==2.31.0
 rjsmin==1.2.1
 webcolors==1.12
-werkzeug==2.2.3
+werkzeug==2.3.8
 zipp==3.11.0
 rcssmin==1.1.1
 zxcvbn==4.4.28


### PR DESCRIPTION
Closes: #1739 

Pip Changes:
- Jinaj2 - `3.1.3` - upgrade from `3.1.2`
- certifi - `2023.11.17` - downgrade from `2023.12.17`
- cryptography - `42.0.2` - upgrade from `39.0.2`
- requests - `2.31.0` - upgrade from `2.28.2`
- werkzeug - `2.3.8` - upgrade from `2.2.3`
