### PR TITLE
Corrected Azure authentication scope documentation

### DIFF
--- a/powerdnsadmin/templates/admin_setting_authentication.html
+++ b/powerdnsadmin/templates/admin_setting_authentication.html
@@ -1283,7 +1283,7 @@
                                                                     You then need to grant admin approval for your
                                                                     organisation.
                                                                 </li>
-                                                                <li>For the Scope, use <b>User.Read openid mail
+                                                                <li>For the Scope, use <b>User.Read openid email
                                                                     profile</b>
                                                                 </li>
                                                                 <li>Replace the [tenantID] in the default URLs for


### PR DESCRIPTION
Resolves #1745

Updated the `mail` reference to `email`.