### PR TITLE
Corrected Session Reaping / Docker Health Check

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,6 +92,6 @@ RUN chown ${USER}:${USER} ./configs /app && \
 
 EXPOSE 80/tcp
 USER ${USER}
-HEALTHCHECK --interval=5s --timeout=5s --start-period=20s --retries=5 CMD wget --output-document=- --quiet --tries=1 http://127.0.0.1${SCRIPT_NAME:-/}
+HEALTHCHECK --interval=5s --timeout=5s --start-period=20s --retries=5 CMD wget --output-document=- --quiet --tries=1 http://127.0.0.1${SCRIPT_NAME:-/}healthcheck
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["gunicorn","powerdnsadmin:create_app()"]

--- a/powerdnsadmin/models/sessions.py
+++ b/powerdnsadmin/models/sessions.py
@@ -26,12 +26,19 @@ class Sessions(db.Model):
     def clean_up_expired_sessions():
         """Clean up expired sessions in the database"""
         from datetime import datetime
-        from sqlalchemy import or_
         from sqlalchemy.exc import SQLAlchemyError
 
         try:
-            db.session.query(Sessions).filter(or_(Sessions.expiry < datetime.now(), Sessions.expiry is None)).delete()
-            db.session.commit()
+            sessions = db.session.query(Sessions)
+            updated = False
+
+            for sess in sessions:
+                if sess.expiry is None or sess.expiry < datetime.now():
+                    db.session.delete(sess)
+                    updated = True
+
+            if updated:
+                db.session.commit()
         except SQLAlchemyError as e:
             db.session.rollback()
             current_app.logger.error(e)

--- a/powerdnsadmin/routes/admin.py
+++ b/powerdnsadmin/routes/admin.py
@@ -212,11 +212,13 @@ class HistoryRecordEntry:
 def before_request():
     # Manage session timeout
     session.permanent = True
-    # current_app.permanent_session_lifetime = datetime.timedelta(
-    #     minutes=int(Setting().get('session_timeout')))
-    current_app.permanent_session_lifetime = datetime.timedelta(
-        minutes=int(Setting().get('session_timeout')))
+    current_app.permanent_session_lifetime = datetime.timedelta(minutes=int(Setting().get('session_timeout')))
     session.modified = True
+
+    # Clean up expired sessions in the database
+    if Setting().get('session_type') == 'sqlalchemy':
+        from ..models.sessions import Sessions
+        Sessions().clean_up_expired_sessions()
 
 
 @admin_bp.route('/server/statistics', methods=['GET'])

--- a/powerdnsadmin/routes/api.py
+++ b/powerdnsadmin/routes/api.py
@@ -170,6 +170,11 @@ def handle_request_is_not_json(err):
 @api_bp.before_request
 @is_json
 def before_request():
+    # Clean up expired sessions in the database
+    if Setting().get('session_type') == 'sqlalchemy':
+        from ..models.sessions import Sessions
+        Sessions().clean_up_expired_sessions()
+
     # Check site is in maintenance mode
     maintenance = Setting().get('maintenance')
     if (maintenance and current_user.is_authenticated and current_user.role.name not in ['Administrator', 'Operator']):

--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -38,18 +38,23 @@ def before_request():
     g.user = current_user
     login_manager.anonymous_user = Anonymous
 
+    # Manage session timeout
+    session.permanent = True
+    current_app.permanent_session_lifetime = datetime.timedelta(
+        minutes=int(Setting().get('session_timeout')))
+    session.modified = True
+
+    # Clean up expired sessions in the database
+    if Setting().get('session_type') == 'sqlalchemy':
+        from ..models.sessions import Sessions
+        Sessions().clean_up_expired_sessions()
+
     # Check site is in maintenance mode
     maintenance = Setting().get('maintenance')
     if maintenance and current_user.is_authenticated and current_user.role.name not in [
             'Administrator', 'Operator'
     ]:
         return render_template('maintenance.html')
-
-    # Manage session timeout
-    session.permanent = True
-    current_app.permanent_session_lifetime = datetime.timedelta(
-        minutes=int(Setting().get('session_timeout')))
-    session.modified = True
 
 
 @domain_bp.route('/<path:domain_name>', methods=['GET'])

--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -66,18 +66,22 @@ def before_request():
     g.user = current_user
     login_manager.anonymous_user = Anonymous
 
+    # Manage session timeout
+    session.permanent = True
+    current_app.permanent_session_lifetime = datetime.timedelta(minutes=int(Setting().get('session_timeout')))
+    session.modified = True
+
+    # Clean up expired sessions in the database
+    if Setting().get('session_type') == 'sqlalchemy':
+        from ..models.sessions import Sessions
+        Sessions().clean_up_expired_sessions()
+
     # Check site is in maintenance mode
     maintenance = Setting().get('maintenance')
     if maintenance and current_user.is_authenticated and current_user.role.name not in [
         'Administrator', 'Operator'
     ]:
         return render_template('maintenance.html')
-
-    # Manage session timeout
-    session.permanent = True
-    current_app.permanent_session_lifetime = datetime.timedelta(
-        minutes=int(Setting().get('session_timeout')))
-    session.modified = True
 
 
 @index_bp.route('/', methods=['GET'])
@@ -88,6 +92,15 @@ def index():
 
 @index_bp.route('/ping', methods=['GET'])
 def ping():
+    return make_response('ok')
+
+
+@index_bp.route('/healthcheck', methods=['GET'])
+def healthcheck():
+    # Manage session timeout
+    session.permanent = False
+    current_app.permanent_session_lifetime = datetime.timedelta(minutes=0)
+    session.modified = True
     return make_response('ok')
 
 

--- a/powerdnsadmin/routes/user.py
+++ b/powerdnsadmin/routes/user.py
@@ -24,13 +24,6 @@ def before_request():
     g.user = current_user
     login_manager.anonymous_user = Anonymous
 
-    # Check site is in maintenance mode
-    maintenance = Setting().get('maintenance')
-    if maintenance and current_user.is_authenticated and current_user.role.name not in [
-            'Administrator', 'Operator'
-    ]:
-        return render_template('maintenance.html')
-
     # Manage session timeout
     session.permanent = True
     current_app.permanent_session_lifetime = datetime.timedelta(
@@ -41,6 +34,13 @@ def before_request():
     if Setting().get('session_type') == 'sqlalchemy':
         from ..models.sessions import Sessions
         Sessions().clean_up_expired_sessions()
+
+    # Check site is in maintenance mode
+    maintenance = Setting().get('maintenance')
+    if maintenance and current_user.is_authenticated and current_user.role.name not in [
+            'Administrator', 'Operator'
+    ]:
+        return render_template('maintenance.html')
 
 
 @user_bp.route('/profile', methods=['GET', 'POST'])


### PR DESCRIPTION
### Resolves: #1750 

Updated the Sessions model reaper functionality to actually function correctly.

Additionally, I added a call to execution for the session reaper to each router's `@domain_bp.before_request` trigger.

I created a `/healthcheck` route that simply returns 'ok' which also expires it's session immediately. Accordingly, I updated the Dockerfile to reference this healthcheck path.