### PR TITLE
Fix LDAP Group Security for FreeIPA

### DIFF
--- a/powerdnsadmin/models/user.py
+++ b/powerdnsadmin/models/user.py
@@ -249,6 +249,7 @@ class User(db.Model):
                 try:
                     ldap_username = ldap.filter.escape_filter_chars(
                         ldap_result[0][0][0])
+                    uid = ldap_result[0][0][1]['uid'][0].decode('utf-8')
 
                     if Setting().get('ldap_type') != 'ad' and not trust_user:
                         # validate ldap user password
@@ -263,7 +264,7 @@ class User(db.Model):
                     if LDAP_GROUP_SECURITY_ENABLED:
                         try:
                             if LDAP_TYPE == 'ldap':
-                                groupSearchFilter = "(&({0}={1}){2})".format(LDAP_FILTER_GROUPNAME, ldap_username, LDAP_FILTER_GROUP)
+                                groupSearchFilter = "(&({0}={1}){2})".format(LDAP_FILTER_GROUPNAME, uid, LDAP_FILTER_GROUP)
                                 current_app.logger.debug('Ldap groupSearchFilter {0}'.format(groupSearchFilter))
                                 if (LDAP_ADMIN_GROUP and self.ldap_search(groupSearchFilter, LDAP_ADMIN_GROUP)):
                                     role_name = 'Administrator'


### PR DESCRIPTION
I know that pull requests arnt being accepted on the current version. I'm more creating this so that it exists to help others who may be trying to do something similar to what I was doing.

The current implementation of LDAP authentication doesn't extract the UID of the user properly, this is a quick and easy patch that can be made to get group security working by properly extracting the UID to pass to the LDAP group search query.

Edit: I don't expect this to actually get merged in. I haven't tested it against any other LDAP providers. This PR is merely for informational purposes.