### PR TITLE
fix(sessions): stop  /healthcheck  from zeroing the global session lifetime

### DIFF
--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -56,10 +56,6 @@ def ping():
 
 @index_bp.route('/healthcheck', methods=['GET'])
 def healthcheck():
-    # Manage session timeout
-    session.permanent = False
-    current_app.permanent_session_lifetime = datetime.timedelta(minutes=0)
-    session.modified = True
     return make_response('ok')
 
 


### PR DESCRIPTION
# Summary

`/healthcheck`  mutates the app-global  permanent_session_lifetime  to 0 minutes on every call. Since health checks run frequently without a session cookie, the next user request that doesn't re-set the lifetime (OIDC and API routes) saves its session with an immediately-expired cookie. This breaks OIDC sign-in with intermittent 400s and logs users out after a couple of requests. This change makes the health check a pure stateless probe.

Root cause

```python
@index_bp.route('/healthcheck', methods=['GET'])
def healthcheck():
    # Manage session timeout
    session.permanent = False
    current_app.permanent_session_lifetime = datetime.timedelta(minutes=0)  # ← bug
    session.modified = True
    return make_response('ok')
```

`current_app.permanent_session_lifetime`  is app-global, shared mutable state. The route handlers that manage the session timeout (`index`,  `dashboard`,  `domain`,  `user`,  `admin`) assign it in their  `before_request` , but the OAuth ( `/oidc/login` ,  `/oidc/authorized`), API, SAML, and dyndns blueprints do not.

Kubernetes liveness/readiness probes (and the Docker  `HEALTHCHECK` ) hit  `/healthcheck`  every ~5s, leaving the global lifetime at 0. When a user request to a non-resetting route follows a probe, the session is saved with  `Expires = now + 0`, so the browser discards the cookie:
- Intermittent OIDC 400: the  state  stored in the session between  `/oidc/login`  and the IdP redirect back to  `/oidc/authorized`  is lost →  `MismatchingStateError`  → "Your sign-in session expired."
- Short-lived sessions: after login, any request on a non-resetting route immediately expires the session cookie.

# Fix

Remove the app-global mutation from the health check; it never belonged there. The probe remains a lightweight endpoint returning 200 and no longer touches shared session state:

```python
@index_bp.route('/healthcheck', methods=['GET'])
def healthcheck():
    # Health checks must not mutate shared app state: zeroing the
    # app-global permanent_session_lifetime here races with user requests,
    # causing sessions to be saved with an immediate expiry (OIDC sign-in
    # intermittently 400s, sessions drop after a couple of requests).
    return make_response('ok')
```

The request-local  `session.permanent` / `session.modified`  lines were also dropped — they were only meaningful alongside the lifetime mutation.

## Why intent is preserved

`/healthcheck`  stays the canonical stateless probe endpoint used by the Docker `HEALTHCHECK`  and Kubernetes probes. It remains cookie-free and lightweight; it just no longer corrupts shared app state.
