### PR TITLE
Fix nullable RRset comments in history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
     editor no longer attempts to read the disabled account-name field from the
     submitted form, which caused Werkzeug to return HTTP 400 before saving the
     associations. (`#1913`)
+-   The changelog now handles PowerDNS RRset history entries with missing or
+    null comment metadata, legacy delete-only entries, and corrupt history
+    details without returning HTTP 500. RRset history is normalized
+    consistently for new API changes and existing database entries. (`#1915`)
 
 ## [2026.08.1] - 2026-08-30
 

--- a/powerdnsadmin/lib/history.py
+++ b/powerdnsadmin/lib/history.py
@@ -1,0 +1,60 @@
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_rrset(rrset):
+    """Return an RRset with a safe, list-valued comments field."""
+    if not isinstance(rrset, dict) or not rrset:
+        if rrset is not None:
+            logger.warning('Ignoring invalid RRset value')
+        return None
+
+    normalized_rrset = dict(rrset)
+    comments = normalized_rrset.get('comments')
+    if comments is None:
+        normalized_rrset['comments'] = []
+    elif not isinstance(comments, list):
+        logger.warning('Ignoring invalid RRset comments value')
+        normalized_rrset['comments'] = []
+
+    return normalized_rrset
+
+
+def normalize_history_detail(detail):
+    """Normalize RRsets in a decoded history detail without mutating it."""
+    normalized_detail = dict(detail)
+    for key in ('add_rrsets', 'del_rrsets'):
+        rrsets = normalized_detail.get(key) or []
+        if not isinstance(rrsets, list):
+            logger.warning('Ignoring invalid history RRsets value')
+            rrsets = []
+        normalized_detail[key] = [
+            normalized_rrset for rrset in rrsets
+            if (normalized_rrset := normalize_rrset(rrset)) is not None
+        ]
+    return normalized_detail
+
+
+def get_records(rrset):
+    """Return records with comments paired by their RRset index."""
+    rrset = normalize_rrset(rrset)
+    if not rrset:
+        return []
+
+    records = rrset.get('records') or []
+    comments = rrset['comments']
+    normalized_records = []
+    for index, record in enumerate(records):
+        if not isinstance(record, dict):
+            continue
+
+        normalized_record = dict(record)
+        normalized_record['comment'] = (
+            comments[index].get('content')
+            if index < len(comments) and isinstance(comments[index], dict)
+            else None
+        )
+        normalized_records.append(normalized_record)
+    return normalized_records

--- a/powerdnsadmin/routes/admin.py
+++ b/powerdnsadmin/routes/admin.py
@@ -25,6 +25,7 @@ from ..models.api_key import ApiKey
 from ..models.base import db
 
 from ..lib.errors import ApiKeyCreateFail
+from ..lib.history import get_records, normalize_history_detail, normalize_rrset
 from ..lib.schema import ApiPlainKeySchema
 from ..lib.user_authorization import user_update_authorization_error
 
@@ -50,17 +51,8 @@ def get_record_changes(del_rrset, add_rrset):
         then `old_state` is None, when it's "deletion" then `new_state` is None.
     """
 
-    def get_records(rrset):
-        """For the given RRset return a combined list of records and comments."""
-        if not rrset or 'records' not in rrset:
-            return []
-        records = [dict(record) for record in rrset['records']]
-        for i, record in enumerate(records):
-            if 'comments' in rrset and len(rrset['comments']) > i:
-                record['comment'] = rrset['comments'][i].get('content', None)
-            else:
-                record['comment'] = None
-        return records
+    del_rrset = normalize_rrset(del_rrset) or {}
+    add_rrset = normalize_rrset(add_rrset) or {}
 
     def record_is_unchanged(old, new):
         """Returns True if the old record is not different from the new one."""
@@ -123,8 +115,13 @@ def extract_changelogs_from_history(histories, record_name=None, record_type=Non
         if entry.detail is None:
             continue
         
-        if "add_rrsets" in entry.detail:
-            details = json.loads(entry.detail)
+        if "add_rrsets" in entry.detail or "del_rrsets" in entry.detail:
+            try:
+                details = normalize_history_detail(json.loads(entry.detail))
+            except (json.JSONDecodeError, TypeError, ValueError):
+                current_app.logger.warning(
+                    'Skipping invalid history detail for history %s', entry.id)
+                continue
             if not details['add_rrsets'] and not details['del_rrsets']:
                 continue
         else:  # not a record entry
@@ -177,8 +174,8 @@ class HistoryRecordEntry:
         # search the add_rrset index into the add_rrset set for the key (name, type)
 
         self.history_entry = history_entry
-        self.add_rrset = add_rrset
-        self.del_rrset = del_rrset
+        self.add_rrset = normalize_rrset(add_rrset) or {}
+        self.del_rrset = normalize_rrset(del_rrset) or {}
         self.change_type = change_type  # "*": edit or unchanged, "+" new tuple(name,type), "-" deleted (name,type) tuple
         self.changed_fields = []  # contains a subset of : [ttl, name, type]
         self.changeSet = []  # all changes for the records of this add_rrset-del_rrset pair
@@ -189,10 +186,10 @@ class HistoryRecordEntry:
             self.changed_fields.append("ttl")
 
         elif change_type == "*":  # edit of unchanged
-            if add_rrset['ttl'] != del_rrset['ttl']:
+            if self.add_rrset['ttl'] != self.del_rrset['ttl']:
                 self.changed_fields.append("ttl")
 
-        self.changeSet = get_record_changes(del_rrset, add_rrset)
+        self.changeSet = get_record_changes(self.del_rrset, self.add_rrset)
 
     def toDict(self):
         return {
@@ -818,7 +815,12 @@ class DetailedHistory():
             self.detailed_msg = ""
             return
 
-        detail_dict = json.loads(history.detail)
+        try:
+            detail_dict = json.loads(history.detail)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            current_app.logger.warning(
+                'Skipping invalid history detail for history %s', history.id)
+            return
 
         if 'domain_type' in detail_dict and 'account_id' in detail_dict:  # this is a zone creation
             self.detailed_msg = render_template_string("""

--- a/powerdnsadmin/routes/api.py
+++ b/powerdnsadmin/routes/api.py
@@ -18,6 +18,7 @@ from ..decorators import (
     allowed_record_types, allowed_record_ttl
 )
 from ..lib import utils, helper
+from ..lib.history import normalize_history_detail
 from ..lib.errors import (
     StructuredException,
     DomainNotExists, DomainAlreadyExists, DomainAccessForbidden,
@@ -1168,11 +1169,11 @@ def api_zone_forward(server_id, zone_id):
                 data = request.get_json(force=True)
                 history = History(
                     msg='Apply record changes to zone {0}'.format(zone_id.rstrip('.')),
-                    detail = json.dumps({
+                    detail = json.dumps(normalize_history_detail({
                         'domain': zone_id.rstrip('.'),
                         'add_rrsets': list(filter(lambda r: r['changetype'] == "REPLACE", data['rrsets'])),
                         'del_rrsets': list(filter(lambda r: r['changetype'] == "DELETE", data['rrsets']))
-                    }),
+                    })),
                     created_by=created_by_value,
                     domain_id=Domain().get_id_by_name(zone_id.rstrip('.')))
                 history.add()

--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -10,6 +10,7 @@ from flask_login import login_required, current_user, login_manager
 from ..lib.utils import pretty_domain_name
 from ..lib.utils import pretty_json
 from ..lib.utils import to_idna
+from ..lib.history import normalize_history_detail
 from ..decorators import can_create_domain, operator_role_required, can_access_domain, can_configure_dnssec, can_remove_domain
 from ..models.user import User, Anonymous
 from ..models.account import Account
@@ -421,7 +422,7 @@ def add():
                         history = History(
                             msg='Applying template {0} to {1} successfully.'.
                             format(template.name, domain_name),
-                            detail = json.dumps({
+                                detail = json.dumps(normalize_history_detail({
                                     'domain':
                                     domain_name,
                                     'template':
@@ -430,7 +431,7 @@ def add():
                                     result['data'][0]['rrsets'],
                                     'del_rrsets':
                                     result['data'][1]['rrsets']
-                                }),
+                                })),
                             created_by=current_user.username,
                             domain_id=domain_id)
                         history.add()

--- a/tests/integration/api/test_history_normalization.py
+++ b/tests/integration/api/test_history_normalization.py
@@ -1,0 +1,65 @@
+import json
+
+from powerdnsadmin.models.history import History
+from powerdnsadmin.routes import api as api_routes
+
+
+class SuccessfulResponse:
+    status_code = 204
+    content = b''
+    headers = {}
+
+
+def test_api_record_history_normalizes_null_comments(
+        app, client, initial_apikey_data, admin_apikey_integration,
+        monkeypatch):
+    with app.app_context():
+        app_settings = {
+            'bg_domain_updates': True,
+            'enable_api_rr_history': True,
+        }
+        monkeypatch.setattr(
+            api_routes.Setting,
+            'get',
+            lambda self, key: app_settings.get(key),
+        )
+        monkeypatch.setattr(
+            api_routes.Domain,
+            'update',
+            lambda self: None,
+        )
+        monkeypatch.setattr(
+            api_routes.Domain,
+            'get_id_by_name',
+            lambda self, name: None,
+        )
+        monkeypatch.setattr(
+            api_routes.helper,
+            'forward_request',
+            lambda: SuccessfulResponse(),
+        )
+
+        response = client.patch(
+            '/api/v1/servers/localhost/zones/example.org.',
+            headers=admin_apikey_integration,
+            json={
+                'rrsets': [{
+                    'name': 'example.org.',
+                    'type': 'TXT',
+                    'changetype': 'REPLACE',
+                    'ttl': 60,
+                    'records': [{
+                        'content': 'challenge',
+                        'disabled': False,
+                    }],
+                    'comments': None,
+                }],
+            },
+        )
+
+        assert response.status_code == 204
+        history = History.query.filter_by(
+            msg='Apply record changes to zone example.org').order_by(
+                History.id.desc()).first()
+        assert history is not None
+        assert json.loads(history.detail)['add_rrsets'][0]['comments'] == []

--- a/tests/smoke/test_admin_history.py
+++ b/tests/smoke/test_admin_history.py
@@ -1,0 +1,46 @@
+import json
+
+from powerdnsadmin.models.history import History
+
+
+def test_history_table_renders_null_rrset_comments(
+        app, logged_in_admin_client):
+    with app.app_context():
+        History(
+            msg='Apply record changes to zone example.org',
+            detail=json.dumps({
+                'domain': 'example.org',
+                'add_rrsets': [{
+                    'name': 'example.org.',
+                    'type': 'TXT',
+                    'ttl': 60,
+                    'records': [{
+                        'content': 'challenge',
+                        'disabled': False,
+                    }],
+                    'comments': None,
+                }],
+                'del_rrsets': [],
+            }),
+            created_by=app.config['TEST_ADMIN_USER'],
+        ).add()
+
+    response = logged_in_admin_client.get(
+        '/admin/history_table?domain_changelog_only_checkbox=on')
+
+    assert response.status_code == 200
+    assert b'challenge' in response.data
+
+
+def test_history_table_skips_corrupt_history_detail(
+        app, logged_in_admin_client):
+    with app.app_context():
+        History(
+            msg='Corrupt history fixture',
+            detail='not-json',
+            created_by=app.config['TEST_ADMIN_USER'],
+        ).add()
+
+    response = logged_in_admin_client.get('/admin/history_table')
+
+    assert response.status_code == 200

--- a/tests/unit/test_history.py
+++ b/tests/unit/test_history.py
@@ -1,0 +1,152 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from powerdnsadmin.lib.history import (
+    get_records,
+    normalize_history_detail,
+    normalize_rrset,
+)
+from powerdnsadmin.routes.admin import (
+    extract_changelogs_from_history,
+    HistoryRecordEntry,
+)
+
+
+def rrset(records=None, comments='missing'):
+    result = {
+        'name': 'example.test.',
+        'type': 'TXT',
+        'ttl': 60,
+    }
+    if records is not None:
+        result['records'] = records
+    if comments != 'missing':
+        result['comments'] = comments
+    return result
+
+
+@pytest.mark.parametrize('comments, expected', [
+    (None, [None]),
+    ([], [None]),
+    ([{'content': 'foo'}], ['foo']),
+    ([{'content': 'foo'}, {'content': 'bar'}], ['foo']),
+    ([{'content': 'foo'}, {'content': 'bar'}, {'content': 'baz'}], ['foo']),
+    ([None], [None]),
+    ('missing', [None]),
+])
+def test_get_records_normalizes_comments(comments, expected):
+    records = get_records(rrset([{'content': 'foo', 'disabled': False}], comments))
+
+    assert records == [{
+        'content': 'foo',
+        'disabled': False,
+        'comment': expected[0],
+    }]
+
+
+@pytest.mark.parametrize('value', [None, {}, {'records': []}])
+def test_get_records_handles_empty_rrsets(value):
+    assert get_records(value) == []
+
+
+def test_get_records_pairs_multiple_records_by_position():
+    records = get_records(rrset([
+         {'content': 'foo', 'disabled': False},
+         {'content': 'bar', 'disabled': True},
+    ], [{'content': 'foo-comment'}, {'content': 'bar-comment'}]))
+
+    assert [record['comment'] for record in records] == [
+         'foo-comment', 'bar-comment']
+
+
+@pytest.mark.parametrize('records', ['invalid', [None], [1]])
+def test_get_records_skips_invalid_records(records):
+    assert get_records(rrset(records)) == []
+
+
+def test_get_records_preserves_comment_index_after_invalid_record():
+       records = get_records(rrset([
+           None,
+           {'content': 'bar', 'disabled': False},
+       ], [{'content': 'ignored'}, {'content': 'bar-comment'}]))
+
+       assert records == [{
+           'content': 'bar',
+           'disabled': False,
+           'comment': 'bar-comment',
+       }]
+
+
+def test_normalize_rrset_does_not_mutate_input():
+    original = rrset([{'content': 'foo'}], None)
+
+    normalize_rrset(original)
+
+    assert original['comments'] is None
+
+
+def test_normalize_rrset_treats_non_list_comments_as_empty():
+    assert normalize_rrset(
+        rrset([{'content': 'foo'}], {'content': 'foo'})
+    )['comments'] == []
+
+
+def test_normalize_history_detail_normalizes_both_rrset_collections():
+    detail = normalize_history_detail({
+        'add_rrsets': [rrset([{'content': 'foo'}], None)],
+        'del_rrsets': None,
+    })
+
+    assert detail['add_rrsets'][0]['comments'] == []
+    assert detail['del_rrsets'] == []
+
+
+def test_extract_changelogs_normalizes_null_comments():
+    detail = {
+        'add_rrsets': [rrset([{'content': 'challenge', 'disabled': False}], None)],
+        'del_rrsets': [],
+    }
+    history = SimpleNamespace(detail=json.dumps(detail))
+
+    changes = extract_changelogs_from_history([history])
+
+    assert changes[0].add_rrset['comments'] == []
+    assert changes[0].changeSet == [
+        (None, {
+            'disabled': False,
+            'content': 'challenge',
+            'comment': None,
+        }, 'addition')
+    ]
+
+
+def test_extract_changelogs_processes_legacy_delete_only_detail():
+    detail = {
+        'del_rrsets': [rrset([{'content': 'old', 'disabled': False}], None)],
+    }
+    history = SimpleNamespace(detail=json.dumps(detail))
+
+    changes = extract_changelogs_from_history([history])
+
+    assert changes[0].del_rrset['comments'] == []
+    assert changes[0].changeSet == [
+        ({'disabled': False, 'content': 'old', 'comment': None}, None, 'deletion')
+    ]
+
+
+def test_extract_changelogs_skips_corrupt_history_detail(app):
+    history = SimpleNamespace(id=42, detail='not-json')
+
+    with app.app_context():
+         assert extract_changelogs_from_history([history]) == []
+
+
+def test_history_record_entry_normalizes_nullable_rrsets():
+    history = SimpleNamespace(created_on=None, created_by=None)
+    add_rrset = rrset([{'content': 'challenge', 'disabled': False}], None)
+
+    entry = HistoryRecordEntry(history, {}, add_rrset, '+')
+
+    assert entry.add_rrset['comments'] == []


### PR DESCRIPTION

## Related issue

Closes #1915

## Summary

PowerDNS-Admin could return HTTP 500 when rendering changelog entries containing an RRset with `"comments": null`.

This change introduces shared RRset and history normalization that:

- Treats missing or null comments as an empty list.
- Preserves positional comment mapping.
- Handles malformed historical records defensively.
- Supports legacy history entries containing only `del_rrsets`.
- Normalizes newly written API and template history entries.
- Skips corrupt history details instead of breaking the changelog page.

Existing database history is normalized at read time, so no database migration is required.

## Testing

Tests were run using the documented Docker test environment.

Result:

- 423 tests passed.
- Coverage: 53.73%.

Additional focused coverage includes:

- Nullable, missing, and empty comments.
- Multiple records and positional comment pairing.
- Invalid records and comments.
- Legacy delete-only history entries.
- Corrupt history JSON.
- API history persistence.
- Authenticated changelog rendering.

- [x] Existing automated tests pass.
- [x] New or changed behavior has relevant automated coverage.
- [x] No UI changes were made; browser and color-mode checks are not applicable.

## Impact

- Database or migration impact: None. Existing history data is handled at read time.
- Configuration or deployment impact: None.
- API or backward-compatibility impact: Existing API behavior is unchanged. API-generated history with null comments is normalized safely.
- Security impact: No new authentication, authorization, injection, or data-exposure behavior. Invalid history data is discarded or skipped safely.

## Screenshots

Not applicable. No visible UI changes were made.

## Changelog

Category: Fixed

Proposed entry:

> The changelog now handles PowerDNS RRset history entries with missing or null
> comment metadata, legacy delete-only entries, and corrupt history details
> without returning HTTP 500. RRset history is normalized consistently for new
> API changes and existing database entries. (#1915)

## AI Assistance Disclosure

This pull request was developed with assistance from GitHub Copilot.

All proposed changes were reviewed, adapted, and validated by the author.
The implementation was tested using the documented Docker test environment,
with 423 automated tests passing and 53.73% coverage.

## Checklist

- [ ] The related issue is approved and assigned to me, or a maintainer requested this work.
- [x] Documentation was updated in `CHANGELOG.md`.
- [x] No credentials, personal information, or generated build artifacts were committed.
- [x] The change is focused and does not include unrelated formatting or refactoring.
- [x] AI assistance from GitHub Copilot is disclosed.